### PR TITLE
Error handling of STEP file parser

### DIFF
--- a/ruststep/Cargo.toml
+++ b/ruststep/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 nom = "6.1.0"
+thiserror = "1.0.24"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/ruststep/src/error.rs
+++ b/ruststep/src/error.rs
@@ -1,0 +1,7 @@
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    ParseFailed(#[from] crate::parser::ParseError),
+}

--- a/ruststep/src/error.rs
+++ b/ruststep/src/error.rs
@@ -2,6 +2,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error(transparent)]
-    ParseFailed(#[from] crate::parser::ParseError),
+    #[error("Failed to parse STEP file:\n{0}")]
+    ParseFailed(String),
 }

--- a/ruststep/src/lib.rs
+++ b/ruststep/src/lib.rs
@@ -11,5 +11,6 @@
 
 #![deny(broken_intra_doc_links)]
 
+pub mod error;
 pub mod parser;
 pub mod primitive;

--- a/ruststep/src/parser/mod.rs
+++ b/ruststep/src/parser/mod.rs
@@ -4,3 +4,25 @@ pub mod basic;
 pub mod combinator;
 pub mod exchange;
 pub mod token;
+
+use std::fmt;
+
+#[derive(Debug)]
+pub struct ParseError {
+    errors: Vec<String>,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for error in &self.errors {
+            write!(f, "{}", error)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+pub fn parse(input: &str) -> Result<exchange::Exchange, ParseError> {
+    todo!()
+}

--- a/ruststep/src/parser/mod.rs
+++ b/ruststep/src/parser/mod.rs
@@ -1,4 +1,16 @@
 //! Parse ASCII exchange structure defined by ISO-10303-21
+//!
+//! ```
+//! use std::{fs, path::*};
+//!
+//! // Read ABC Dataset's STEP file format example
+//! let step_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+//!     .join("tests/steps/00000050_80d90bfdd2e74e709956122a_step_000.step");
+//! let step_str = fs::read_to_string(step_file).unwrap();
+//!
+//! // Parse STEP file into `Exchange` struct
+//! let ex = ruststep::parser::parse(&step_str).unwrap();
+//! ```
 
 pub mod basic;
 pub mod combinator;

--- a/ruststep/src/parser/mod.rs
+++ b/ruststep/src/parser/mod.rs
@@ -5,24 +5,15 @@ pub mod combinator;
 pub mod exchange;
 pub mod token;
 
-use std::fmt;
+use crate::error::*;
+use nom::Finish;
 
-#[derive(Debug)]
-pub struct ParseError {
-    errors: Vec<String>,
-}
-
-impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for error in &self.errors {
-            write!(f, "{}", error)?;
+pub fn parse(input: &str) -> Result<exchange::Exchange> {
+    match exchange::exchange_file(input).finish() {
+        Ok((_residual, ex)) => Ok(ex),
+        Err(e) => {
+            let error = nom::error::convert_error(input, e);
+            Err(Error::ParseFailed(error))
         }
-        Ok(())
     }
-}
-
-impl std::error::Error for ParseError {}
-
-pub fn parse(input: &str) -> Result<exchange::Exchange, ParseError> {
-    todo!()
 }


### PR DESCRIPTION
- Add `ruststep::error` module
- Add `ruststep::parser::parse` function