### PR TITLE
Entity/Variable ID as u64

### DIFF
--- a/ruststep/src/error.rs
+++ b/ruststep/src/error.rs
@@ -1,7 +1,9 @@
+use crate::parser::TokenizeFailed;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Failed to parse STEP file:\n{0}")]
-    ParseFailed(String),
+    #[error(transparent)]
+    TokenizeFailed(#[from] TokenizeFailed),
 }

--- a/ruststep/src/parser/exchange/data.rs
+++ b/ruststep/src/parser/exchange/data.rs
@@ -32,8 +32,8 @@ pub fn entity_instance_list(input: &str) -> ParseResult<Vec<EntityInstance>> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum EntityInstance {
-    Simple { name: String, record: Record },
-    Complex { name: String, subsuper: Vec<Record> },
+    Simple { name: u64, record: Record },
+    Complex { name: u64, subsuper: Vec<Record> },
 }
 
 /// entity_instance = [simple_entity_instance] | [complex_entity_instance] .

--- a/ruststep/src/parser/mod.rs
+++ b/ruststep/src/parser/mod.rs
@@ -1,7 +1,21 @@
-//! Tokenize ASCII exchange structure defined by ISO-10303-21
+//! Tokenize ASCII exchange structure (or STEP-file) defined by ISO-10303-21
 //!
-//! Be sure that this submodule responsible only for tokenize into abstract syntax tree (AST),
+//! This submodule responsible only for tokenize into abstract syntax tree (AST),
 //! not for semantic validation.
+//!
+//! STEP-file consists of following sections:
+//!
+//! - HEADER
+//! - ANCHOR (optional)
+//! - REFERENCE (optional)
+//! - DATA
+//! - SIGNATURE (optional)
+//!
+//! ANCHOR, REFERENCE, and SIGNATURE sections are optional.
+//! The syntax of STEP-file is common through schemas,
+//! i.e. the tokenize of STEP-file can be done without reading any EXPRESS schema.
+//! A target schema is specified in the HEADER section,
+//! and it determines how we should understand AST.
 //!
 //! Example
 //! --------

--- a/ruststep/src/parser/token.rs
+++ b/ruststep/src/parser/token.rs
@@ -233,7 +233,7 @@ mod tests {
     }
 
     #[test]
-    fn u64_overflow() {
+    fn instance_name() {
         let (res, s) = super::entity_instance_name("#18446744073709551615" /* u64::MAX */)
             .finish()
             .unwrap();
@@ -246,6 +246,7 @@ mod tests {
         assert_eq!(res, "");
         assert_eq!(s, std::u64::MAX);
 
+        // u64 overflow
         assert!(
             super::entity_instance_name("#18446744073709551616" /* u64::MAX + 1 */)
                 .finish()
@@ -256,5 +257,13 @@ mod tests {
                 .finish()
                 .is_err()
         );
+
+        // zeros should be ignored
+        let (res, s) = super::entity_instance_name("#001").finish().unwrap();
+        assert_eq!(res, "");
+        assert_eq!(s, 1);
+        let (res, s) = super::value_instance_name("@001").finish().unwrap();
+        assert_eq!(res, "");
+        assert_eq!(s, 1);
     }
 }

--- a/ruststep/src/parser/token.rs
+++ b/ruststep/src/parser/token.rs
@@ -69,18 +69,18 @@ pub fn enumeration(input: &str) -> ParseResult<String> {
 #[derive(Debug, Clone, PartialEq)]
 pub enum LValue {
     /// Like `#11`
-    Entity(String),
+    Entity(u64),
     /// Like `@11`
-    Value(String),
+    Value(u64),
 }
 
 /// Right hand side value
 #[derive(Debug, Clone, PartialEq)]
 pub enum RValue {
     /// Like `#11`
-    Entity(String),
+    Entity(u64),
     /// Like `@11`
-    Value(String),
+    Value(u64),
     /// Like `#CONST_ENTITY`
     ConstantEntity(String),
     /// Like `@CONST_VALUE`
@@ -88,16 +88,34 @@ pub enum RValue {
 }
 
 /// entity_instance_name = `#` ( [digit] ) { [digit] } .
-pub fn entity_instance_name(input: &str) -> ParseResult<String> {
+///
+/// As discussed in ISO-10303-21 6.4.4.3 Entity instance names,
+///
+/// > NOTE 2 Leading zeros in entity instance names are ignored so "#001" is the same identifier as "#1".
+///
+/// leading zeros are ignored, and convert into `u64` type.
+///
+/// Panics
+/// -------
+/// - FIXME: If the input cannot be represented by `u64`, i.e. larger than [std::u64::MAX]
+///
+pub fn entity_instance_name(input: &str) -> ParseResult<u64> {
     tuple((char('#'), digit1))
-        .map(|(_sharp, name): (_, &str)| name.to_string())
+        .map(|(_sharp, name): (_, &str)| name.parse().expect("Cannot represented in u64"))
         .parse(input)
 }
 
 /// value_instance_name = `@` ( [digit] ) { [digit] } .
-pub fn value_instance_name(input: &str) -> ParseResult<String> {
+///
+/// Leading zeros are ignored like as [entity_instance_name].
+///
+/// Panics
+/// -------
+/// - FIXME: If the input cannot be represented by `u64`, i.e. larger than [std::u64::MAX]
+///
+pub fn value_instance_name(input: &str) -> ParseResult<u64> {
     tuple((char('@'), digit1))
-        .map(|(_sharp, name): (_, &str)| name.to_string())
+        .map(|(_sharp, name): (_, &str)| name.parse().expect("Cannot represented in u64"))
         .parse(input)
 }
 


### PR DESCRIPTION
Split from #16 

- Use `u64` instead of `String` in entity and variable IDs
- Create `TokenizedFailed` error type 