### PR TITLE
Refactoring ast::types

### DIFF
--- a/espr/src/ast/algorithm.rs
+++ b/espr/src/ast/algorithm.rs
@@ -108,7 +108,7 @@ pub struct FormalParameter {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Constant {
     pub name: String,
-    pub ty: ConcreteType,
+    pub ty: UnderlyingType,
     pub expr: Expression,
 }
 

--- a/espr/src/ast/types.rs
+++ b/espr/src/ast/types.rs
@@ -1,7 +1,6 @@
 //! AST for type declaration
 
 use crate::ast::{algorithm::*, expression::*};
-use derive_more::From;
 
 #[cfg(doc)]
 use crate::parser::*;
@@ -25,18 +24,35 @@ pub struct TypeDecl {
     pub where_clause: Option<WhereClause>,
 }
 
-/// Output of [constructed_types]
-#[derive(Debug, Clone, PartialEq, Eq, From)]
-pub enum ConstructedType {
+/// Output of [underlying_type]
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnderlyingType {
+    // Concrete Types
+    Simple(SimpleType),
+    Reference(String),
+    Set {
+        bound: Option<Bound>,
+        base: Box<UnderlyingType>,
+    },
+    Bag {
+        bound: Option<Bound>,
+        base: Box<UnderlyingType>,
+    },
+    List {
+        unique: bool,
+        bound: Option<Bound>,
+        base: Box<UnderlyingType>,
+    },
+    Array {
+        unique: bool,
+        optional: bool,
+        bound: Bound,
+        base: Box<UnderlyingType>,
+    },
+
+    // Constructed Types
     Enumeration(EnumerationType),
     Select(SelectType),
-}
-
-/// Output of [underlying_type]
-#[derive(Debug, Clone, PartialEq, From)]
-pub enum UnderlyingType {
-    Constructed(ConstructedType),
-    Concrete(ConcreteType),
 }
 
 /// Output of [select_type]
@@ -108,32 +124,6 @@ pub enum ParameterType {
 pub struct EnumerationType {
     pub extensiblity: Extensiblity,
     pub items: Vec<String>,
-}
-
-/// Output of [concrete_types]
-#[derive(Debug, Clone, PartialEq)]
-pub enum ConcreteType {
-    Simple(SimpleType),
-    Reference(String),
-    Set {
-        bound: Option<Bound>,
-        base: Box<ConcreteType>,
-    },
-    Bag {
-        bound: Option<Bound>,
-        base: Box<ConcreteType>,
-    },
-    List {
-        unique: bool,
-        bound: Option<Bound>,
-        base: Box<ConcreteType>,
-    },
-    Array {
-        unique: bool,
-        optional: bool,
-        bound: Bound,
-        base: Box<ConcreteType>,
-    },
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/espr/src/ast/types.rs
+++ b/espr/src/ast/types.rs
@@ -55,14 +55,10 @@ pub enum UnderlyingType {
         extensiblity: Extensiblity,
         items: Vec<String>,
     },
-    Select(SelectType),
-}
-
-/// Output of [select_type]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SelectType {
-    pub extensiblity: Extensiblity,
-    pub types: Vec<String>,
+    Select {
+        extensiblity: Extensiblity,
+        types: Vec<String>,
+    },
 }
 
 /// Output of [width_spec]

--- a/espr/src/ast/types.rs
+++ b/espr/src/ast/types.rs
@@ -51,7 +51,10 @@ pub enum UnderlyingType {
     },
 
     // Constructed Types
-    Enumeration(EnumerationType),
+    Enumeration {
+        extensiblity: Extensiblity,
+        items: Vec<String>,
+    },
     Select(SelectType),
 }
 
@@ -117,13 +120,6 @@ pub enum ParameterType {
     },
     GenericEntity(Option<String>),
     Generic(Option<String>),
-}
-
-/// Output of [enumeration_type]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EnumerationType {
-    pub extensiblity: Extensiblity,
-    pub items: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/espr/src/ast/types.rs
+++ b/espr/src/ast/types.rs
@@ -5,18 +5,7 @@ use crate::ast::{algorithm::*, expression::*};
 #[cfg(doc)]
 use crate::parser::*;
 
-/// `EXTENSIBLE` and `GENERIC_ENTITY` keywords for [select_type] and [enumeration_type]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Extensiblity {
-    /// No `EXTENSIBLE`
-    None,
-    /// `EXTENSIBLE`
-    Extensible,
-    /// `EXTENSIBLE GENERIC_ENTITY`, which is allowed only for `SELECT`
-    GenericEntity,
-}
-
-/// Output of [type_decl]
+/// Type declaration by [type_decl].
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypeDecl {
     pub type_id: String,
@@ -24,30 +13,30 @@ pub struct TypeDecl {
     pub where_clause: Option<WhereClause>,
 }
 
-/// Output of [underlying_type]
+/// Underlying type of a type declaration
 #[derive(Debug, Clone, PartialEq)]
 pub enum UnderlyingType {
     // Concrete Types
     Simple(SimpleType),
     Reference(String),
     Set {
-        bound: Option<Bound>,
         base: Box<UnderlyingType>,
+        bound: Option<Bound>,
     },
     Bag {
-        bound: Option<Bound>,
         base: Box<UnderlyingType>,
+        bound: Option<Bound>,
     },
     List {
-        unique: bool,
-        bound: Option<Bound>,
         base: Box<UnderlyingType>,
+        bound: Option<Bound>,
+        unique: bool,
     },
     Array {
+        base: Box<UnderlyingType>,
+        bound: Bound,
         unique: bool,
         optional: bool,
-        bound: Bound,
-        base: Box<UnderlyingType>,
     },
 
     // Constructed Types
@@ -61,14 +50,42 @@ pub enum UnderlyingType {
     },
 }
 
-/// Output of [width_spec]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WidthSpec {
-    pub width: usize,
-    pub fixed: bool,
+/// Parameter type appears when *using* the type
+/// e.g. in attribute definition, function parameter, and so on.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParameterType {
+    Simple(SimpleType),
+    Named(String),
+    Set {
+        base: Box<ParameterType>,
+        bound: Option<Bound>,
+    },
+    Bag {
+        base: Box<ParameterType>,
+        bound: Option<Bound>,
+    },
+    List {
+        base: Box<ParameterType>,
+        bound: Option<Bound>,
+        unique: bool,
+    },
+    Array {
+        base: Box<ParameterType>,
+        bound: Option<Bound>,
+        unique: bool,
+        optional: bool,
+    },
+
+    Aggregate {
+        base: Box<ParameterType>,
+        label: Option<String>,
+    },
+
+    GenericEntity(Option<String>),
+    Generic(Option<String>),
 }
 
-/// Output of [simple_types]
+/// Primitive types parsed by [simple_types]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SimpleType {
     /// 8.1.1 Number data type
@@ -87,39 +104,26 @@ pub enum SimpleType {
     Binary { width_spec: Option<WidthSpec> },
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum ParameterType {
-    Named(String),
-    Simple(SimpleType),
-    Set {
-        ty: Box<ParameterType>,
-        bound_spec: Option<Bound>,
-    },
-    Bag {
-        ty: Box<ParameterType>,
-        bound_spec: Option<Bound>,
-    },
-    List {
-        ty: Box<ParameterType>,
-        bound_spec: Option<Bound>,
-        unique: bool,
-    },
-    Array {
-        ty: Box<ParameterType>,
-        bound_spec: Option<Bound>,
-        unique: bool,
-        optional: bool,
-    },
-    Aggregate {
-        ty: Box<ParameterType>,
-        label: Option<String>,
-    },
-    GenericEntity(Option<String>),
-    Generic(Option<String>),
+/// Output of [width_spec]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WidthSpec {
+    pub width: usize,
+    pub fixed: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Bound {
     pub lower: Expression,
     pub upper: Expression,
+}
+
+/// `EXTENSIBLE` and `GENERIC_ENTITY` keywords for [select_type] and [enumeration_type]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Extensiblity {
+    /// No `EXTENSIBLE`
+    None,
+    /// `EXTENSIBLE`
+    Extensible,
+    /// `EXTENSIBLE GENERIC_ENTITY`, which is allowed only for `SELECT`
+    GenericEntity,
 }

--- a/espr/src/parser/types/concrete.rs
+++ b/espr/src/parser/types/concrete.rs
@@ -5,22 +5,22 @@ use super::{
 use crate::ast::expression::*;
 
 /// 193 concrete_types = [aggregation_types] | [simple_types] | [type_ref].
-pub fn concrete_types(input: &str) -> ParseResult<ConcreteType> {
+pub fn concrete_types(input: &str) -> ParseResult<UnderlyingType> {
     alt((
         aggregation_types,
-        simple_types.map(|ty| ConcreteType::Simple(ty)),
-        type_ref.map(|s| ConcreteType::Reference(s)),
+        simple_types.map(|ty| UnderlyingType::Simple(ty)),
+        type_ref.map(|s| UnderlyingType::Reference(s)),
     ))
     .parse(input)
 }
 
 /// 172 aggregation_types = [array_type] | [bag_type] | [list_type] | [set_type] .
-pub fn aggregation_types(input: &str) -> ParseResult<ConcreteType> {
+pub fn aggregation_types(input: &str) -> ParseResult<UnderlyingType> {
     alt((array_type, bag_type, list_type, set_type)).parse(input)
 }
 
 /// 175 array_type = ARRAY [bound_spec] OF \[ OPTIONAL \] \[ UNIQUE \] [instantiable_type] .
-pub fn array_type(input: &str) -> ParseResult<ConcreteType> {
+pub fn array_type(input: &str) -> ParseResult<UnderlyingType> {
     tuple((
         tag("ARRAY"),
         bound_spec,
@@ -30,7 +30,7 @@ pub fn array_type(input: &str) -> ParseResult<ConcreteType> {
         instantiable_type,
     ))
     .map(
-        |(_set, bound, _of, optional, unique, base)| ConcreteType::Array {
+        |(_set, bound, _of, optional, unique, base)| UnderlyingType::Array {
             bound,
             unique: unique.is_some(),
             optional: optional.is_some(),
@@ -41,9 +41,9 @@ pub fn array_type(input: &str) -> ParseResult<ConcreteType> {
 }
 
 /// 180 bag_type = BAG \[ [bound_spec] \] OF [instantiable_type] .
-pub fn bag_type(input: &str) -> ParseResult<ConcreteType> {
+pub fn bag_type(input: &str) -> ParseResult<UnderlyingType> {
     tuple((tag("BAG"), opt(bound_spec), tag("OF"), instantiable_type))
-        .map(|(_set, bound, _of, base)| ConcreteType::Bag {
+        .map(|(_set, bound, _of, base)| UnderlyingType::Bag {
             bound,
             base: Box::new(base),
         })
@@ -51,7 +51,7 @@ pub fn bag_type(input: &str) -> ParseResult<ConcreteType> {
 }
 
 /// 250 list_type = LIST \[ [bound_spec] \] OF \[ UNIQUE \] [instantiable_type] .
-pub fn list_type(input: &str) -> ParseResult<ConcreteType> {
+pub fn list_type(input: &str) -> ParseResult<UnderlyingType> {
     tuple((
         tag("LIST"),
         opt(bound_spec),
@@ -59,7 +59,7 @@ pub fn list_type(input: &str) -> ParseResult<ConcreteType> {
         opt(tag("UNIQUE")),
         instantiable_type,
     ))
-    .map(|(_set, bound, _of, unique, base)| ConcreteType::List {
+    .map(|(_set, bound, _of, unique, base)| UnderlyingType::List {
         bound,
         unique: unique.is_some(),
         base: Box::new(base),
@@ -68,9 +68,9 @@ pub fn list_type(input: &str) -> ParseResult<ConcreteType> {
 }
 
 /// 303 set_type = SET \[ [bound_spec] \] OF [instantiable_type] .
-pub fn set_type(input: &str) -> ParseResult<ConcreteType> {
+pub fn set_type(input: &str) -> ParseResult<UnderlyingType> {
     tuple((tag("SET"), opt(bound_spec), tag("OF"), instantiable_type))
-        .map(|(_set, bound, _of, base)| ConcreteType::Set {
+        .map(|(_set, bound, _of, base)| UnderlyingType::Set {
             bound,
             base: Box::new(base),
         })
@@ -95,10 +95,10 @@ pub fn bound_spec(input: &str) -> ParseResult<Bound> {
 }
 
 /// 240 instantiable_type = [concrete_types] | [entity_ref] .
-pub fn instantiable_type(input: &str) -> ParseResult<ConcreteType> {
+pub fn instantiable_type(input: &str) -> ParseResult<UnderlyingType> {
     alt((
         concrete_types,
-        entity_ref.map(|r| ConcreteType::Reference(r)),
+        entity_ref.map(|r| UnderlyingType::Reference(r)),
     ))
     .parse(input)
 }

--- a/espr/src/parser/types/enumeration.rs
+++ b/espr/src/parser/types/enumeration.rs
@@ -11,7 +11,7 @@ pub fn enumeration_items(input: &str) -> ParseResult<Vec<String>> {
 }
 
 /// 213 enumeration_type = \[ EXTENSIBLE \] ENUMERATION \[ ( OF [enumeration_items] ) | enumeration_extension \] .
-pub fn enumeration_type(input: &str) -> ParseResult<EnumerationType> {
+pub fn enumeration_type(input: &str) -> ParseResult<UnderlyingType> {
     // FIXME enumeration_extension
     tuple((
         opt(tag("EXTENSIBLE")),
@@ -19,14 +19,16 @@ pub fn enumeration_type(input: &str) -> ParseResult<EnumerationType> {
         tag("OF"),
         enumeration_items,
     ))
-    .map(|(extensiblility, _start, _of, items)| EnumerationType {
-        extensiblity: if extensiblility.is_some() {
-            Extensiblity::Extensible
-        } else {
-            Extensiblity::None
+    .map(
+        |(extensiblility, _start, _of, items)| UnderlyingType::Enumeration {
+            extensiblity: if extensiblility.is_some() {
+                Extensiblity::Extensible
+            } else {
+                Extensiblity::None
+            },
+            items,
         },
-        items,
-    })
+    )
     .parse(input)
 }
 
@@ -43,7 +45,7 @@ mod tests {
         assert_eq!(residual, "");
         assert_eq!(
             e,
-            super::EnumerationType {
+            super::UnderlyingType::Enumeration {
                 extensiblity: super::Extensiblity::None,
                 items: vec![
                     "up".to_string(),
@@ -64,7 +66,7 @@ mod tests {
         assert_eq!(residual, "");
         assert_eq!(
             e,
-            super::EnumerationType {
+            super::UnderlyingType::Enumeration {
                 extensiblity: super::Extensiblity::Extensible,
                 items: vec![
                     "up".to_string(),

--- a/espr/src/parser/types/mod.rs
+++ b/espr/src/parser/types/mod.rs
@@ -15,11 +15,7 @@ use crate::ast::types::*;
 
 /// 198 constructed_types = [enumeration_type] | [select_type] .
 pub fn constructed_types(input: &str) -> ParseResult<UnderlyingType> {
-    alt((
-        enumeration_type,
-        select_type.map(|s| UnderlyingType::Select(s)),
-    ))
-    .parse(input)
+    alt((enumeration_type, select_type)).parse(input)
 }
 
 /// 332 underlying_type = [concrete_types] | [constructed_types] .

--- a/espr/src/parser/types/mod.rs
+++ b/espr/src/parser/types/mod.rs
@@ -16,7 +16,7 @@ use crate::ast::types::*;
 /// 198 constructed_types = [enumeration_type] | [select_type] .
 pub fn constructed_types(input: &str) -> ParseResult<UnderlyingType> {
     alt((
-        enumeration_type.map(|e| UnderlyingType::Enumeration(e)),
+        enumeration_type,
         select_type.map(|s| UnderlyingType::Select(s)),
     ))
     .parse(input)

--- a/espr/src/parser/types/mod.rs
+++ b/espr/src/parser/types/mod.rs
@@ -14,21 +14,17 @@ use super::{combinator::*, entity::*, identifier::*};
 use crate::ast::types::*;
 
 /// 198 constructed_types = [enumeration_type] | [select_type] .
-pub fn constructed_types(input: &str) -> ParseResult<ConstructedType> {
+pub fn constructed_types(input: &str) -> ParseResult<UnderlyingType> {
     alt((
-        enumeration_type.map(|e| ConstructedType::Enumeration(e)),
-        select_type.map(|s| ConstructedType::Select(s)),
+        enumeration_type.map(|e| UnderlyingType::Enumeration(e)),
+        select_type.map(|s| UnderlyingType::Select(s)),
     ))
     .parse(input)
 }
 
 /// 332 underlying_type = [concrete_types] | [constructed_types] .
 pub fn underlying_type(input: &str) -> ParseResult<UnderlyingType> {
-    alt((
-        concrete_types.map(|ty| UnderlyingType::Concrete(ty)),
-        constructed_types.map(|ty| UnderlyingType::Constructed(ty)),
-    ))
-    .parse(input)
+    alt((concrete_types, constructed_types)).parse(input)
 }
 
 /// 327 type_decl = TYPE [type_id] `=` [underlying_type] `;` \[ [where_clause] \] END_TYPE `;` .
@@ -78,9 +74,9 @@ mod tests {
             ty,
             super::TypeDecl {
                 type_id: "my_type".to_string(),
-                underlying_type: super::UnderlyingType::Concrete(super::ConcreteType::Simple(
-                    super::SimpleType::String_ { width_spec: None }
-                )),
+                underlying_type: super::UnderlyingType::Simple(super::SimpleType::String_ {
+                    width_spec: None
+                }),
                 where_clause: None,
             }
         );

--- a/espr/src/parser/types/select.rs
+++ b/espr/src/parser/types/select.rs
@@ -19,7 +19,7 @@ pub fn select_extension(input: &str) -> ParseResult<(String, Vec<String>)> {
 }
 
 /// 302 select_type = \[ EXTENSIBLE \[ GENERIC_ENTITY \] \] SELECT \[ [select_list] | [select_extension] \] .
-pub fn select_type(input: &str) -> ParseResult<SelectType> {
+pub fn select_type(input: &str) -> ParseResult<UnderlyingType> {
     // FIXME support select_extension
 
     // `GENERIC_ENTITY` only appears in `select_type` declaration.
@@ -42,12 +42,12 @@ pub fn select_type(input: &str) -> ParseResult<SelectType> {
     ))
     .map(|(opt, _select, types)| {
         if let Some((extensiblity, _spaces)) = opt {
-            SelectType {
+            UnderlyingType::Select {
                 extensiblity,
                 types,
             }
         } else {
-            SelectType {
+            UnderlyingType::Select {
                 extensiblity: Extensiblity::None,
                 types,
             }
@@ -65,8 +65,16 @@ mod tests {
     fn select() {
         let (res, (s, _remarks)) = super::select_type("SELECT (a, b)").finish().unwrap();
         assert_eq!(res, "");
-        assert_eq!(s.extensiblity, Extensiblity::None);
-        assert_eq!(s.types[0], "a");
-        assert_eq!(s.types[1], "b");
+        if let UnderlyingType::Select {
+            extensiblity,
+            types,
+        } = s
+        {
+            assert_eq!(extensiblity, Extensiblity::None);
+            assert_eq!(types[0], "a");
+            assert_eq!(types[1], "b");
+        } else {
+            panic!()
+        }
     }
 }


### PR DESCRIPTION
Flatten `ast::types::UnderlyingType` and `ast::types::ParameterType` 