### PR TITLE
Subtype downcast code generation

### DIFF
--- a/espr/src/ast/entity.rs
+++ b/espr/src/ast/entity.rs
@@ -25,6 +25,19 @@ pub struct Entity {
     pub where_clause: Option<WhereClause>,
 }
 
+impl Entity {
+    pub fn has_supertype_decl(&self) -> bool {
+        if let Some(c) = &self.constraint {
+            match c {
+                Constraint::AbstractSuperType(..) | Constraint::SuperTypeRule(..) => true,
+                Constraint::AbstractEntity => false,
+            }
+        } else {
+            false
+        }
+    }
+}
+
 /// Intermediate output of [entity_body]
 #[derive(Debug, Clone, PartialEq)]
 pub struct EntityBody {

--- a/espr/src/semantics/entity.rs
+++ b/espr/src/semantics/entity.rs
@@ -9,6 +9,9 @@ pub struct Entity {
     name: String,
     attributes: Vec<EntityAttribute>,
     subtypes: Option<Vec<TypeRef>>,
+
+    // FIXME This assumes that `SUPERTYPE` declaration exists for all supertypes.
+    has_supertype_decl: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,6 +66,7 @@ impl Legalize for Entity {
             name: entity.name.clone(),
             attributes,
             subtypes,
+            has_supertype_decl: entity.has_supertype_decl(),
         })
     }
 }
@@ -122,6 +126,16 @@ impl ToTokens for Entity {
                 )*
             }
         });
+
+        if self.has_supertype_decl {
+            let trait_name = format_ident!("{}Any", name);
+            tokens.append_all(quote! {
+                pub trait #trait_name : ::std::any::Any + ::std::fmt::Debug {}
+            });
+            tokens.append_all(quote! {
+                impl #trait_name for #name {}
+            });
+        }
     }
 }
 

--- a/espr/src/semantics/entity.rs
+++ b/espr/src/semantics/entity.rs
@@ -92,7 +92,9 @@ impl ToTokens for Entity {
         if let Some(subtypes) = &self.subtypes {
             for ty in subtypes {
                 let (attr, ty) = match ty {
-                    TypeRef::Named { name, .. } => (format_ident!("{}", name), ty),
+                    TypeRef::Named { name, .. } | TypeRef::Entity { name, .. } => {
+                        (format_ident!("{}", name), ty)
+                    }
                     _ => unreachable!(),
                 };
 

--- a/espr/src/semantics/entity.rs
+++ b/espr/src/semantics/entity.rs
@@ -116,6 +116,20 @@ impl ToTokens for Entity {
 
                 attr_name.push(attr);
                 attr_type.push(ty.to_token_stream());
+
+                if let TypeRef::Entity {
+                    name: supertype_name,
+                    has_supertype_decl,
+                    ..
+                } = ty
+                {
+                    if *has_supertype_decl {
+                        let any_trait = format_ident!("{}Any", supertype_name.to_pascal_case());
+                        tokens.append_all(quote! {
+                            impl #any_trait for #name {}
+                        });
+                    }
+                }
             }
         }
         tokens.append_all(quote! {

--- a/espr/src/semantics/entity.rs
+++ b/espr/src/semantics/entity.rs
@@ -102,18 +102,6 @@ impl ToTokens for Entity {
                     _ => unreachable!(),
                 };
 
-                // impl Deref for single subtype case
-                if subtypes.len() == 1 {
-                    tokens.append_all(quote! {
-                        impl ::std::ops::Deref for #name {
-                            type Target = #ty;
-                            fn deref(&self) -> &Self::Target {
-                                &self.#attr
-                            }
-                        }
-                    });
-                }
-
                 attr_name.push(attr);
                 attr_type.push(ty.to_token_stream());
 

--- a/espr/src/semantics/entity.rs
+++ b/espr/src/semantics/entity.rs
@@ -133,7 +133,7 @@ impl ToTokens for Entity {
             }
         }
         tokens.append_all(quote! {
-            #[derive(Clone, Debug, PartialEq, derive_new::new)]
+            #[derive(Debug, derive_new::new)]
             pub struct #name {
                 #(
                 pub #attr_name : #attr_type,

--- a/espr/src/semantics/namespace.rs
+++ b/espr/src/semantics/namespace.rs
@@ -58,7 +58,7 @@ impl Namespace {
                         .iter()
                         .map(|e| {
                             let name = e.name.clone();
-                            if let Some(c) = e.constraint {
+                            if let Some(c) = &e.constraint {
                                 use ast::entity::Constraint;
                                 match c {
                                     Constraint::AbstractSuperType(..)

--- a/espr/src/semantics/namespace.rs
+++ b/espr/src/semantics/namespace.rs
@@ -88,12 +88,12 @@ impl Namespace {
                 .0
                 .get(&scope)
                 .expect("Scope is not belong to the namespace");
-            for (entity_name, is_supertype) in &ns.entities {
+            for (entity_name, has_supertype_decl) in &ns.entities {
                 if name == entity_name {
                     return Ok(TypeRef::Entity {
                         name: name.to_string(),
                         scope,
-                        is_supertype: *is_supertype,
+                        has_supertype_decl: *has_supertype_decl,
                     });
                 }
             }

--- a/espr/src/semantics/namespace.rs
+++ b/espr/src/semantics/namespace.rs
@@ -8,7 +8,7 @@ pub struct Names {
     /// Declared as `SCHEMA`
     schemas: Vec<String>,
     /// Declared as `ENTITY`
-    entities: Vec<(String, bool /* is supertype */)>,
+    entities: Vec<(String, bool /* has supertype decl */)>,
     /// Declared as an attribute
     attributes: Vec<String>,
     /// Declared as `TYPE`
@@ -56,21 +56,7 @@ impl Namespace {
                     entities: schema
                         .entities
                         .iter()
-                        .map(|e| {
-                            // FIXME This assumes that `SUPERTYPE` declaration exists for all
-                            // supertypes. There is no guarantee for it generally.
-                            let name = e.name.clone();
-                            if let Some(c) = &e.constraint {
-                                use ast::entity::Constraint;
-                                match c {
-                                    Constraint::AbstractSuperType(..)
-                                    | Constraint::SuperTypeRule(..) => (name, true),
-                                    Constraint::AbstractEntity => (name, false),
-                                }
-                            } else {
-                                (name, false)
-                            }
-                        })
+                        .map(|e| (e.name.clone(), e.has_supertype_decl()))
                         .collect(),
                     attributes: Vec::new(),
                     types: schema.types.iter().map(|e| e.type_id.clone()).collect(),

--- a/espr/src/semantics/namespace.rs
+++ b/espr/src/semantics/namespace.rs
@@ -57,6 +57,8 @@ impl Namespace {
                         .entities
                         .iter()
                         .map(|e| {
+                            // FIXME This assumes that `SUPERTYPE` declaration exists for all
+                            // supertypes. There is no guarantee for it generally.
                             let name = e.name.clone();
                             if let Some(c) = &e.constraint {
                                 use ast::entity::Constraint;

--- a/espr/src/semantics/type_decl.rs
+++ b/espr/src/semantics/type_decl.rs
@@ -70,7 +70,7 @@ impl ToTokens for TypeDecl {
                     .map(|i| format_ident!("{}", i.to_pascal_case()))
                     .collect();
                 tokens.append_all(quote! {
-                    #[derive(Debug, Clone, PartialEq)]
+                    #[derive(Debug)]
                     pub enum #id {
                         #( #items ),*
                     }
@@ -102,7 +102,7 @@ impl ToTokens for TypeDecl {
                     }
                 }
                 tokens.append_all(quote! {
-                    #[derive(Debug, Clone, PartialEq)]
+                    #[derive(Debug)]
                     pub enum #id {
                         #(#entries(#entry_types)),*
                     }

--- a/espr/src/semantics/type_decl.rs
+++ b/espr/src/semantics/type_decl.rs
@@ -76,12 +76,38 @@ impl ToTokens for TypeDecl {
                     }
                 });
             }
-            UnderlyingType::Select(types) => tokens.append_all(quote! {
-                #[derive(Debug, Clone, PartialEq)]
-                pub enum #id {
-                    #(#types(Box<#types>)),*
+            UnderlyingType::Select(types) => {
+                let mut entries = Vec::new();
+                let mut entry_types = Vec::new();
+                for ty in types {
+                    match ty {
+                        TypeRef::Entity {
+                            name,
+                            has_supertype_decl,
+                            ..
+                        } => {
+                            let name = format_ident!("{}", name.to_pascal_case());
+                            entries.push(quote! { #name });
+                            if *has_supertype_decl {
+                                // avoid Box<Box<XxxAny>>
+                                entry_types.push(quote! { #ty });
+                            } else {
+                                entry_types.push(quote! { Box<#ty> });
+                            }
+                        }
+                        _ => {
+                            entries.push(ty.to_token_stream());
+                            entry_types.push(quote! { Box<#ty> });
+                        }
+                    }
                 }
-            }),
+                tokens.append_all(quote! {
+                    #[derive(Debug, Clone, PartialEq)]
+                    pub enum #id {
+                        #(#entries(#entry_types)),*
+                    }
+                });
+            }
         }
     }
 }

--- a/espr/src/semantics/type_ref.rs
+++ b/espr/src/semantics/type_ref.rs
@@ -28,7 +28,7 @@ pub enum TypeRef {
     Entity {
         name: String,
         scope: Scope,
-        is_supertype: bool,
+        has_supertype_decl: bool,
     },
     SimpleType(ast::types::SimpleType),
     Set {
@@ -109,9 +109,11 @@ impl ToTokens for TypeRef {
                 tokens.append_all(quote! { #name });
             }
             Entity {
-                name, is_supertype, ..
+                name,
+                has_supertype_decl,
+                ..
             } => {
-                if *is_supertype {
+                if *has_supertype_decl {
                     // TODO use Box<dyn Any>
                     let name = format_ident!("{}", name.to_pascal_case());
                     tokens.append_all(quote! { #name });

--- a/espr/src/semantics/type_ref.rs
+++ b/espr/src/semantics/type_ref.rs
@@ -25,6 +25,11 @@ pub enum TypeRef {
         name: String,
         scope: Scope,
     },
+    Entity {
+        name: String,
+        scope: Scope,
+        is_supertype: bool,
+    },
     SimpleType(ast::types::SimpleType),
     Set {
         base: Box<TypeRef>,
@@ -102,6 +107,18 @@ impl ToTokens for TypeRef {
             Named { name, .. } => {
                 let name = format_ident!("{}", name.to_pascal_case());
                 tokens.append_all(quote! { #name });
+            }
+            Entity {
+                name, is_supertype, ..
+            } => {
+                if *is_supertype {
+                    // TODO use Box<dyn Any>
+                    let name = format_ident!("{}", name.to_pascal_case());
+                    tokens.append_all(quote! { #name });
+                } else {
+                    let name = format_ident!("{}", name.to_pascal_case());
+                    tokens.append_all(quote! { #name });
+                }
             }
             Set { base, .. } | List { base, .. } => {
                 tokens.append_all(quote! { Vec<#base> });

--- a/espr/src/semantics/type_ref.rs
+++ b/espr/src/semantics/type_ref.rs
@@ -114,9 +114,8 @@ impl ToTokens for TypeRef {
                 ..
             } => {
                 if *has_supertype_decl {
-                    // TODO use Box<dyn Any>
-                    let name = format_ident!("{}", name.to_pascal_case());
-                    tokens.append_all(quote! { #name });
+                    let name = format_ident!("{}Any", name.to_pascal_case());
+                    tokens.append_all(quote! { Box<dyn #name> });
                 } else {
                     let name = format_ident!("{}", name.to_pascal_case());
                     tokens.append_all(quote! { #name });

--- a/ruststep/src/ap000.rs
+++ b/ruststep/src/ap000.rs
@@ -90,7 +90,6 @@ use std::{
     any::{Any, TypeId},
     collections::HashMap,
     fmt::Debug,
-    ops::{Deref, DerefMut},
 };
 
 #[cfg(doc)]
@@ -291,17 +290,6 @@ pub struct Sub {
     pub b: f64,
 }
 impl BaseAny for Sub {}
-impl Deref for Sub {
-    type Target = Base;
-    fn deref(&self) -> &Self::Target {
-        &self.base
-    }
-}
-impl DerefMut for Sub {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.base
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/ruststep/src/ap201.rs
+++ b/ruststep/src/ap201.rs
@@ -1,21 +1,21 @@
 #![allow(dead_code)]
 pub mod explicit_draughting {
     use crate::primitive::*;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum ApprovedItem {
         DrawingRevision(Box<DrawingRevision>),
         DrawingSheetRevision(Box<DrawingSheetRevision>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum AreaOrView {
         PresentationArea(Box<PresentationArea>),
         PresentationView(Box<PresentationView>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum Axis2Placement {
         Axis2Placement2D(Box<Axis2Placement2D>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum BSplineCurveForm {
         EllipticArc,
         PolylineForm,
@@ -24,7 +24,7 @@ pub mod explicit_draughting {
         Unspecified,
         HyperbolicArc,
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum BoxCharacteristicSelect {
         BoxHeight(Box<BoxHeight>),
         BoxWidth(Box<BoxWidth>),
@@ -35,100 +35,100 @@ pub mod explicit_draughting {
     pub type BoxRotateAngle = PlaneAngleMeasure;
     pub type BoxSlantAngle = PlaneAngleMeasure;
     pub type BoxWidth = PositiveRatioMeasure;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum CharacterSpacingSelect {
         LengthMeasure(Box<LengthMeasure>),
         RatioMeasure(Box<RatioMeasure>),
         MeasureWithUnit(Box<dyn MeasureWithUnitAny>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum CharacterStyleSelect {
         TextStyleForDefinedFont(Box<TextStyleForDefinedFont>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum CharacterizedDefinition {
         CharacterizedProductDefinition(Box<CharacterizedProductDefinition>),
         ShapeDefinition(Box<ShapeDefinition>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum CharacterizedProductDefinition {
         ProductDefinition(Box<ProductDefinition>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum ClassifiedItem {
         DrawingRevision(Box<DrawingRevision>),
         DrawingSheetRevision(Box<DrawingSheetRevision>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum ContractedItem {
         DrawingRevision(Box<DrawingRevision>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum CurveFontOrScaledCurveFontSelect {
         CurveStyleFontSelect(Box<CurveStyleFontSelect>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum CurveOrAnnotationCurveOccurrence {
         Curve(Box<dyn CurveAny>),
         AnnotationCurveOccurrence(Box<AnnotationCurveOccurrence>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum CurveOrRender {
         CurveStyle(Box<CurveStyle>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum CurveStyleFontSelect {
         CurveStyleFont(Box<CurveStyleFont>),
         PreDefinedCurveFont(Box<PreDefinedCurveFont>),
         ExternallyDefinedCurveFont(Box<ExternallyDefinedCurveFont>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum DateTimeSelect {
         Date(Box<dyn DateAny>),
     }
     pub type DayInMonthNumber = i64;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum DefinedSymbolSelect {
         PreDefinedSymbol(Box<PreDefinedSymbol>),
         ExternallyDefinedSymbol(Box<ExternallyDefinedSymbol>),
     }
     pub type DimensionCount = i64;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum DimensionExtentUsage {
         Origin,
         Target,
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum DraughtingCalloutElement {
         AnnotationTextOccurrence(Box<AnnotationTextOccurrence>),
         AnnotationSymbolOccurrence(Box<AnnotationSymbolOccurrence>),
         AnnotationCurveOccurrence(Box<AnnotationCurveOccurrence>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum DraughtingGroupedItem {
         AnnotationOccurrence(Box<dyn AnnotationOccurrenceAny>),
         GeometricSetSelect(Box<GeometricSetSelect>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum DraughtingOrganizationItem {
         ProductDefinitionFormation(Box<ProductDefinitionFormation>),
         DrawingRevision(Box<DrawingRevision>),
         DrawingSheetRevision(Box<DrawingSheetRevision>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum DraughtingPresentedItemSelect {
         ProductDefinitionFormation(Box<ProductDefinitionFormation>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum DraughtingTitledItem {
         DrawingRevision(Box<DrawingRevision>),
         DrawingSheetRevision(Box<DrawingSheetRevision>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum FillAreaStyleTileShapeSelect {
         FillAreaStyleTileSymbolWithStyle(Box<FillAreaStyleTileSymbolWithStyle>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum FillStyleSelect {
         FillAreaStyleColour(Box<FillAreaStyleColour>),
         ExternallyDefinedTileStyle(Box<ExternallyDefinedTileStyle>),
@@ -136,36 +136,36 @@ pub mod explicit_draughting {
         ExternallyDefinedHatchStyle(Box<ExternallyDefinedHatchStyle>),
         FillAreaStyleHatching(Box<FillAreaStyleHatching>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum FontSelect {
         PreDefinedTextFont(Box<PreDefinedTextFont>),
         ExternallyDefinedTextFont(Box<ExternallyDefinedTextFont>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum GeometricSetSelect {
         Point(Box<dyn PointAny>),
         Curve(Box<dyn CurveAny>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum HidingOrBlankingSelect {
         PresentationArea(Box<PresentationArea>),
         PresentationView(Box<PresentationView>),
         AnnotationFillArea(Box<AnnotationFillArea>),
     }
     pub type Identifier = String;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum InvisibilityContext {
         PresentationLayerUsage(Box<PresentationLayerUsage>),
         PresentationRepresentation(Box<PresentationRepresentation>),
         PresentationSet(Box<PresentationSet>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum InvisibleItem {
         StyledItem(Box<StyledItem>),
         PresentationLayerAssignment(Box<PresentationLayerAssignment>),
         PresentationRepresentation(Box<PresentationRepresentation>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum KnotType {
         UniformKnots,
         QuasiUniformKnots,
@@ -173,13 +173,13 @@ pub mod explicit_draughting {
         Unspecified,
     }
     pub type Label = String;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum LayeredItem {
         PresentationRepresentation(Box<PresentationRepresentation>),
         RepresentationItem(Box<RepresentationItem>),
     }
     pub type LengthMeasure = f64;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum MeasureValue {
         LengthMeasure(Box<LengthMeasure>),
         PlaneAngleMeasure(Box<PlaneAngleMeasure>),
@@ -189,12 +189,12 @@ pub mod explicit_draughting {
         PositiveRatioMeasure(Box<PositiveRatioMeasure>),
     }
     pub type MonthInYearNumber = i64;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum NullStyle {
         Null,
     }
     pub type ParameterValue = f64;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum PersonOrganizationSelect {
         Person(Box<Person>),
         Organization(Box<Organization>),
@@ -204,18 +204,18 @@ pub mod explicit_draughting {
     pub type PositiveLengthMeasure = LengthMeasure;
     pub type PositiveRatioMeasure = RatioMeasure;
     pub type PresentableText = String;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum PresentationRepresentationSelect {
         PresentationRepresentation(Box<PresentationRepresentation>),
         PresentationSet(Box<PresentationSet>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum PresentationSizeAssignmentSelect {
         PresentationView(Box<PresentationView>),
         PresentationArea(Box<PresentationArea>),
         AreaInSet(Box<AreaInSet>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum PresentationStyleSelect {
         CurveStyle(Box<CurveStyle>),
         SymbolStyle(Box<SymbolStyle>),
@@ -224,11 +224,11 @@ pub mod explicit_draughting {
         NullStyle(Box<NullStyle>),
     }
     pub type RatioMeasure = f64;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum ShapeDefinition {
         ProductDefinitionShape(Box<ProductDefinitionShape>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum SiPrefix {
         Exa,
         Pico,
@@ -247,7 +247,7 @@ pub mod explicit_draughting {
         Kilo,
         Deca,
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum SiUnitName {
         Hertz,
         DegreeCelsius,
@@ -278,74 +278,74 @@ pub mod explicit_draughting {
         Weber,
         Coulomb,
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum SizeSelect {
         PositiveLengthMeasure(Box<PositiveLengthMeasure>),
         MeasureWithUnit(Box<dyn MeasureWithUnitAny>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum SourceItem {
         Identifier(Box<Identifier>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum SpecifiedItem {
         DrawingRevision(Box<DrawingRevision>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum StyleContextSelect {
         Representation(Box<Representation>),
         RepresentationItem(Box<RepresentationItem>),
         PresentationSet(Box<PresentationSet>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum SymbolStyleSelect {
         SymbolColour(Box<SymbolColour>),
     }
     pub type Text = String;
     pub type TextAlignment = Label;
     pub type TextDelineation = Label;
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum TextOrCharacter {
         AnnotationText(Box<AnnotationText>),
         CompositeText(Box<CompositeText>),
         TextLiteral(Box<TextLiteral>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum TextPath {
         Up,
         Right,
         Down,
         Left,
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum TransitionCode {
         Discontinuous,
         ContSameGradientSameCurvature,
         ContSameGradient,
         Continuous,
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum TrimmingPreference {
         Parameter,
         Unspecified,
         Cartesian,
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum TrimmingSelect {
         CartesianPoint(Box<CartesianPoint>),
         ParameterValue(Box<ParameterValue>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum Unit {
         NamedUnit(Box<dyn NamedUnitAny>),
     }
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub enum VectorOrDirection {
         Vector(Box<Vector>),
         Direction(Box<Direction>),
     }
     pub type YearNumber = i64;
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Address {
         pub internal_location: Option<Label>,
         pub street_number: Option<Label>,
@@ -366,7 +366,7 @@ pub mod explicit_draughting {
             &self.dimension_curve_directed_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct AngularDimension {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
     }
@@ -377,7 +377,7 @@ pub mod explicit_draughting {
         }
     }
     impl AnnotationOccurrenceAny for AnnotationCurveOccurrence {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct AnnotationCurveOccurrence {
         pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
     }
@@ -388,7 +388,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for AnnotationFillArea {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct AnnotationFillArea {
         pub boundaries: Vec<Box<dyn CurveAny>>,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
@@ -400,7 +400,7 @@ pub mod explicit_draughting {
         }
     }
     impl AnnotationOccurrenceAny for AnnotationFillAreaOccurrence {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct AnnotationFillAreaOccurrence {
         pub fill_style_target: Box<dyn PointAny>,
         pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
@@ -411,7 +411,7 @@ pub mod explicit_draughting {
             &self.styled_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct AnnotationOccurrence {
         pub styled_item: StyledItem,
     }
@@ -423,7 +423,7 @@ pub mod explicit_draughting {
             &self.annotation_symbol_occurrence
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct AnnotationSubfigureOccurrence {
         pub annotation_symbol_occurrence: AnnotationSymbolOccurrence,
     }
@@ -433,7 +433,7 @@ pub mod explicit_draughting {
             &self.mapped_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct AnnotationSymbol {
         pub mapped_item: MappedItem,
     }
@@ -444,7 +444,7 @@ pub mod explicit_draughting {
         }
     }
     impl AnnotationOccurrenceAny for AnnotationSymbolOccurrence {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct AnnotationSymbolOccurrence {
         pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
     }
@@ -454,7 +454,7 @@ pub mod explicit_draughting {
             &self.mapped_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct AnnotationText {
         pub mapped_item: MappedItem,
     }
@@ -465,59 +465,59 @@ pub mod explicit_draughting {
         }
     }
     impl AnnotationOccurrenceAny for AnnotationTextOccurrence {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct AnnotationTextOccurrence {
         pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ApplicationContext {
         pub application: Text,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ApplicationContextElement {
         pub name: Label,
         pub frame_of_reference: ApplicationContext,
     }
     pub trait ApplicationContextElementAny: ::std::any::Any + ::std::fmt::Debug {}
     impl ApplicationContextElementAny for ApplicationContextElement {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ApplicationProtocolDefinition {
         pub status: Label,
         pub application_interpreted_model_schema_name: Label,
         pub application_protocol_year: YearNumber,
         pub application: ApplicationContext,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Approval {
         pub status: ApprovalStatus,
         pub level: Label,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ApprovalAssignment {
         pub assigned_approval: Approval,
     }
     pub trait ApprovalAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
     impl ApprovalAssignmentAny for ApprovalAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ApprovalDateTime {
         pub date_time: DateTimeSelect,
         pub dated_approval: Approval,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ApprovalPersonOrganization {
         pub person_organization: PersonOrganizationSelect,
         pub authorized_approval: Approval,
         pub role: ApprovalRole,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ApprovalRole {
         pub role: Label,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ApprovalStatus {
         pub name: Label,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct AreaInSet {
         pub area: PresentationArea,
         pub in_set: PresentationSet,
@@ -529,7 +529,7 @@ pub mod explicit_draughting {
         }
     }
     impl PlacementAny for Axis2Placement2D {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Axis2Placement2D {
         pub ref_direction: Option<Direction>,
         pub placement: Box<dyn PlacementAny>,
@@ -541,7 +541,7 @@ pub mod explicit_draughting {
         }
     }
     impl BoundedCurveAny for BSplineCurve {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct BSplineCurve {
         pub degree: i64,
         pub control_points_list: Vec<CartesianPoint>,
@@ -559,7 +559,7 @@ pub mod explicit_draughting {
         }
     }
     impl BSplineCurveAny for BSplineCurveWithKnots {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct BSplineCurveWithKnots {
         pub knot_multiplicities: Vec<i64>,
         pub knots: Vec<ParameterValue>,
@@ -573,7 +573,7 @@ pub mod explicit_draughting {
         }
     }
     impl BSplineCurveAny for BezierCurve {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct BezierCurve {
         pub b_spline_curve: Box<dyn BSplineCurveAny>,
     }
@@ -584,7 +584,7 @@ pub mod explicit_draughting {
         }
     }
     impl CurveAny for BoundedCurve {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct BoundedCurve {
         pub curve: Box<dyn CurveAny>,
     }
@@ -597,7 +597,7 @@ pub mod explicit_draughting {
         }
     }
     impl DateAny for CalendarDate {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CalendarDate {
         pub day_component: DayInMonthNumber,
         pub month_component: MonthInYearNumber,
@@ -609,7 +609,7 @@ pub mod explicit_draughting {
             &self.mapped_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CameraImage {
         pub mapped_item: MappedItem,
     }
@@ -619,7 +619,7 @@ pub mod explicit_draughting {
             &self.camera_image
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CameraImage2DWithScale {
         pub camera_image: CameraImage,
     }
@@ -630,7 +630,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for CameraModel {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CameraModel {
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
@@ -643,7 +643,7 @@ pub mod explicit_draughting {
         }
     }
     impl CameraModelAny for CameraModelD2 {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CameraModelD2 {
         pub view_window: PlanarBox,
         pub view_window_clipping: bool,
@@ -655,7 +655,7 @@ pub mod explicit_draughting {
             &self.representation_map
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CameraUsage {
         pub representation_map: RepresentationMap,
     }
@@ -666,7 +666,7 @@ pub mod explicit_draughting {
         }
     }
     impl PointAny for CartesianPoint {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CartesianPoint {
         pub coordinates: Vec<LengthMeasure>,
         pub point: Box<dyn PointAny>,
@@ -678,12 +678,12 @@ pub mod explicit_draughting {
         }
     }
     impl ConicAny for Circle {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Circle {
         pub radius: PositiveLengthMeasure,
         pub conic: Box<dyn ConicAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Colour {}
     impl ::std::ops::Deref for ColourRgb {
         type Target = ColourSpecification;
@@ -691,7 +691,7 @@ pub mod explicit_draughting {
             &self.colour_specification
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ColourRgb {
         pub red: f64,
         pub green: f64,
@@ -704,7 +704,7 @@ pub mod explicit_draughting {
             &self.colour
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ColourSpecification {
         pub name: Colour,
         pub colour: Colour,
@@ -716,13 +716,13 @@ pub mod explicit_draughting {
         }
     }
     impl BoundedCurveAny for CompositeCurve {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CompositeCurve {
         pub segments: Vec<CompositeCurveSegment>,
         pub self_intersect: Logical,
         pub bounded_curve: Box<dyn BoundedCurveAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CompositeCurveSegment {
         pub transition: TransitionCode,
         pub same_sense: bool,
@@ -735,7 +735,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for CompositeText {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CompositeText {
         pub collected_text: Vec<TextOrCharacter>,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
@@ -746,7 +746,7 @@ pub mod explicit_draughting {
             &self.composite_text
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CompositeTextWithAssociatedCurves {
         pub associated_curves: Vec<Box<dyn CurveAny>>,
         pub composite_text: CompositeText,
@@ -757,7 +757,7 @@ pub mod explicit_draughting {
             &self.composite_text
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CompositeTextWithBlankingBox {
         pub blanking: PlanarBox,
         pub composite_text: CompositeText,
@@ -768,7 +768,7 @@ pub mod explicit_draughting {
             &self.composite_text
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CompositeTextWithExtent {
         pub extent: PlanarExtent,
         pub composite_text: CompositeText,
@@ -780,7 +780,7 @@ pub mod explicit_draughting {
         }
     }
     impl CurveAny for Conic {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Conic {
         pub position: Axis2Placement,
         pub curve: Box<dyn CurveAny>,
@@ -793,24 +793,24 @@ pub mod explicit_draughting {
             &self.invisibility
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ContextDependentInvisibility {
         pub presentation_context: InvisibilityContext,
         pub invisibility: Invisibility,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Contract {
         pub name: Label,
         pub purpose: Text,
         pub kind: ContractType,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ContractAssignment {
         pub assigned_contract: Contract,
     }
     pub trait ContractAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
     impl ContractAssignmentAny for ContractAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ContractType {
         pub description: Label,
     }
@@ -821,7 +821,7 @@ pub mod explicit_draughting {
         }
     }
     impl NamedUnitAny for ConversionBasedUnit {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ConversionBasedUnit {
         pub name: Label,
         pub conversion_factor: Box<dyn MeasureWithUnitAny>,
@@ -834,7 +834,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for Curve {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Curve {
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
@@ -846,28 +846,28 @@ pub mod explicit_draughting {
             &self.dimension_curve_directed_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CurveDimension {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CurveStyle {
         pub name: Label,
         pub curve_font: CurveFontOrScaledCurveFontSelect,
         pub curve_width: SizeSelect,
         pub curve_colour: Colour,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CurveStyleFont {
         pub name: Label,
         pub pattern_list: Vec<CurveStyleFontPattern>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct CurveStyleFontPattern {
         pub visible_segment_length: PositiveLengthMeasure,
         pub invisible_segment_length: PositiveLengthMeasure,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Date {
         pub year_component: YearNumber,
     }
@@ -879,7 +879,7 @@ pub mod explicit_draughting {
             &self.draughting_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DatumFeatureCallout {
         pub draughting_callout: DraughtingCallout,
     }
@@ -889,7 +889,7 @@ pub mod explicit_draughting {
             &self.draughting_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DatumTargetCallout {
         pub draughting_callout: DraughtingCallout,
     }
@@ -900,7 +900,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for DefinedSymbol {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DefinedSymbol {
         pub definition: DefinedSymbolSelect,
         pub target: SymbolTarget,
@@ -912,7 +912,7 @@ pub mod explicit_draughting {
             &self.dimension_curve_directed_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DiameterDimension {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
     }
@@ -922,7 +922,7 @@ pub mod explicit_draughting {
             &self.draughting_callout_relationship
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DimensionCalloutComponentRelationship {
         pub draughting_callout_relationship: DraughtingCalloutRelationship,
     }
@@ -932,7 +932,7 @@ pub mod explicit_draughting {
             &self.draughting_callout_relationship
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DimensionCalloutRelationship {
         pub draughting_callout_relationship: DraughtingCalloutRelationship,
     }
@@ -942,7 +942,7 @@ pub mod explicit_draughting {
             &self.annotation_curve_occurrence
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DimensionCurve {
         pub annotation_curve_occurrence: AnnotationCurveOccurrence,
     }
@@ -952,7 +952,7 @@ pub mod explicit_draughting {
             &self.draughting_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DimensionCurveDirectedCallout {
         pub draughting_callout: DraughtingCallout,
     }
@@ -962,7 +962,7 @@ pub mod explicit_draughting {
             &self.terminator_symbol
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DimensionCurveTerminator {
         pub role: DimensionExtentUsage,
         pub terminator_symbol: TerminatorSymbol,
@@ -973,11 +973,11 @@ pub mod explicit_draughting {
             &self.draughting_callout_relationship
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DimensionPair {
         pub draughting_callout_relationship: DraughtingCalloutRelationship,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DimensionalExponents {
         pub length_exponent: f64,
         pub mass_exponent: f64,
@@ -994,26 +994,26 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for Direction {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Direction {
         pub direction_ratios: Vec<f64>,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Document {
         pub id: Identifier,
         pub name: Label,
         pub description: Text,
         pub kind: DocumentType,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DocumentReference {
         pub assigned_document: Document,
         pub source: Label,
     }
     pub trait DocumentReferenceAny: ::std::any::Any + ::std::fmt::Debug {}
     impl DocumentReferenceAny for DocumentReference {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DocumentType {
         pub product_data_type: Label,
     }
@@ -1024,7 +1024,7 @@ pub mod explicit_draughting {
         }
     }
     impl AnnotationOccurrenceAny for DraughtingAnnotationOccurrence {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingAnnotationOccurrence {
         pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
     }
@@ -1035,7 +1035,7 @@ pub mod explicit_draughting {
         }
     }
     impl ApprovalAssignmentAny for DraughtingApprovalAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingApprovalAssignment {
         pub approved_items: Vec<ApprovedItem>,
         pub approval_assignment: Box<dyn ApprovalAssignmentAny>,
@@ -1047,12 +1047,12 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for DraughtingCallout {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingCallout {
         pub contents: Vec<DraughtingCalloutElement>,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingCalloutRelationship {
         pub name: Label,
         pub description: Text,
@@ -1066,7 +1066,7 @@ pub mod explicit_draughting {
         }
     }
     impl ContractAssignmentAny for DraughtingContractAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingContractAssignment {
         pub items: Vec<ContractedItem>,
         pub contract_assignment: Box<dyn ContractAssignmentAny>,
@@ -1077,7 +1077,7 @@ pub mod explicit_draughting {
             &self.drawing_revision
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingDrawingRevision {
         pub drawing_revision: DrawingRevision,
     }
@@ -1087,7 +1087,7 @@ pub mod explicit_draughting {
             &self.draughting_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingElements {
         pub draughting_callout: DraughtingCallout,
     }
@@ -1098,7 +1098,7 @@ pub mod explicit_draughting {
         }
     }
     impl GroupAssignmentAny for DraughtingGroupAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingGroupAssignment {
         pub items: Vec<DraughtingGroupedItem>,
         pub group_assignment: Box<dyn GroupAssignmentAny>,
@@ -1109,7 +1109,7 @@ pub mod explicit_draughting {
             &self.representation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingModel {
         pub representation: Representation,
     }
@@ -1120,7 +1120,7 @@ pub mod explicit_draughting {
         }
     }
     impl OrganizationAssignmentAny for DraughtingOrganizationAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingOrganizationAssignment {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
         pub organization_assignment: Box<dyn OrganizationAssignmentAny>,
@@ -1132,7 +1132,7 @@ pub mod explicit_draughting {
         }
     }
     impl PersonAndOrganizationAssignmentAny for DraughtingPersonAndOrganizationAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingPersonAndOrganizationAssignment {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
         pub person_and_organization_assignment: Box<dyn PersonAndOrganizationAssignmentAny>,
@@ -1144,7 +1144,7 @@ pub mod explicit_draughting {
         }
     }
     impl PersonAssignmentAny for DraughtingPersonAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingPersonAssignment {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
         pub person_assignment: Box<dyn PersonAssignmentAny>,
@@ -1155,7 +1155,7 @@ pub mod explicit_draughting {
             &self.pre_defined_colour
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingPreDefinedColour {
         pub pre_defined_colour: PreDefinedColour,
     }
@@ -1165,7 +1165,7 @@ pub mod explicit_draughting {
             &self.pre_defined_curve_font
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingPreDefinedCurveFont {
         pub pre_defined_curve_font: PreDefinedCurveFont,
     }
@@ -1175,7 +1175,7 @@ pub mod explicit_draughting {
             &self.pre_defined_text_font
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingPreDefinedTextFont {
         pub pre_defined_text_font: PreDefinedTextFont,
     }
@@ -1186,7 +1186,7 @@ pub mod explicit_draughting {
         }
     }
     impl PresentedItemAny for DraughtingPresentedItem {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingPresentedItem {
         pub items: Vec<DraughtingPresentedItemSelect>,
         pub presented_item: Box<dyn PresentedItemAny>,
@@ -1198,7 +1198,7 @@ pub mod explicit_draughting {
         }
     }
     impl SecurityClassificationAssignmentAny for DraughtingSecurityClassificationAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingSecurityClassificationAssignment {
         pub assigned_items: Vec<ClassifiedItem>,
         pub security_classification_assignment: Box<dyn SecurityClassificationAssignmentAny>,
@@ -1210,7 +1210,7 @@ pub mod explicit_draughting {
         }
     }
     impl DocumentReferenceAny for DraughtingSpecificationReference {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingSpecificationReference {
         pub specified_items: Vec<SpecifiedItem>,
         pub document_reference: Box<dyn DocumentReferenceAny>,
@@ -1221,7 +1221,7 @@ pub mod explicit_draughting {
             &self.symbol_representation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingSubfigureRepresentation {
         pub symbol_representation: SymbolRepresentation,
     }
@@ -1231,7 +1231,7 @@ pub mod explicit_draughting {
             &self.symbol_representation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingSymbolRepresentation {
         pub symbol_representation: SymbolRepresentation,
     }
@@ -1241,17 +1241,17 @@ pub mod explicit_draughting {
             &self.text_literal_with_delineation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingTextLiteralWithDelineation {
         pub text_literal_with_delineation: TextLiteralWithDelineation,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DraughtingTitle {
         pub items: Vec<DraughtingTitledItem>,
         pub language: Label,
         pub contents: Text,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DrawingDefinition {
         pub drawing_number: Identifier,
         pub drawing_type: Option<Label>,
@@ -1262,7 +1262,7 @@ pub mod explicit_draughting {
             &self.presentation_set
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DrawingRevision {
         pub revision_identifier: Identifier,
         pub drawing_identifier: DrawingDefinition,
@@ -1275,7 +1275,7 @@ pub mod explicit_draughting {
             &self.draughting_symbol_representation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DrawingSheetLayout {
         pub draughting_symbol_representation: DraughtingSymbolRepresentation,
     }
@@ -1285,7 +1285,7 @@ pub mod explicit_draughting {
             &self.presentation_area
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DrawingSheetRevision {
         pub revision_identifier: Identifier,
         pub presentation_area: PresentationArea,
@@ -1296,7 +1296,7 @@ pub mod explicit_draughting {
             &self.area_in_set
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct DrawingSheetRevisionUsage {
         pub sheet_number: Identifier,
         pub area_in_set: AreaInSet,
@@ -1308,13 +1308,13 @@ pub mod explicit_draughting {
         }
     }
     impl ConicAny for Ellipse {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Ellipse {
         pub semi_axis_1: PositiveLengthMeasure,
         pub semi_axis_2: PositiveLengthMeasure,
         pub conic: Box<dyn ConicAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ExternalSource {
         pub source_id: SourceItem,
     }
@@ -1324,17 +1324,17 @@ pub mod explicit_draughting {
             &self.externally_defined_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ExternallyDefinedCurveFont {
         pub externally_defined_item: ExternallyDefinedItem,
     }
     impl GeometricRepresentationItemAny for ExternallyDefinedHatchStyle {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ExternallyDefinedHatchStyle {
         pub externally_defined_item: ExternallyDefinedItem,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ExternallyDefinedItem {
         pub item_id: SourceItem,
         pub source: ExternalSource,
@@ -1345,7 +1345,7 @@ pub mod explicit_draughting {
             &self.externally_defined_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ExternallyDefinedSymbol {
         pub externally_defined_item: ExternallyDefinedItem,
     }
@@ -1355,22 +1355,22 @@ pub mod explicit_draughting {
             &self.externally_defined_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ExternallyDefinedTextFont {
         pub externally_defined_item: ExternallyDefinedItem,
     }
     impl GeometricRepresentationItemAny for ExternallyDefinedTileStyle {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ExternallyDefinedTileStyle {
         pub externally_defined_item: ExternallyDefinedItem,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct FillAreaStyle {
         pub name: Label,
         pub fill_styles: Vec<FillStyleSelect>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct FillAreaStyleColour {
         pub name: Label,
         pub fill_colour: Colour,
@@ -1382,7 +1382,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for FillAreaStyleHatching {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct FillAreaStyleHatching {
         pub hatch_line_appearance: CurveStyle,
         pub start_of_next_hatch_line: OneDirectionRepeatFactor,
@@ -1398,7 +1398,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for FillAreaStyleTileSymbolWithStyle {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct FillAreaStyleTileSymbolWithStyle {
         pub symbol: AnnotationSymbolOccurrence,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
@@ -1410,7 +1410,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for FillAreaStyleTiles {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct FillAreaStyleTiles {
         pub tiling_pattern: TwoDirectionRepeatFactor,
         pub tiles: Vec<FillAreaStyleTileShapeSelect>,
@@ -1424,7 +1424,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricSetAny for GeometricCurveSet {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct GeometricCurveSet {
         pub geometric_set: Box<dyn GeometricSetAny>,
     }
@@ -1434,7 +1434,7 @@ pub mod explicit_draughting {
             &self.representation_context
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct GeometricRepresentationContext {
         pub coordinate_space_dimension: DimensionCount,
         pub representation_context: RepresentationContext,
@@ -1445,7 +1445,7 @@ pub mod explicit_draughting {
             &self.representation_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct GeometricRepresentationItem {
         pub representation_item: RepresentationItem,
     }
@@ -1458,7 +1458,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for GeometricSet {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct GeometricSet {
         pub elements: Vec<GeometricSetSelect>,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
@@ -1471,7 +1471,7 @@ pub mod explicit_draughting {
             &self.draughting_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct GeometricalToleranceCallout {
         pub draughting_callout: DraughtingCallout,
     }
@@ -1481,7 +1481,7 @@ pub mod explicit_draughting {
             &self.shape_representation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct GeometricallyBounded2DWireframeRepresentation {
         pub shape_representation: ShapeRepresentation,
     }
@@ -1491,23 +1491,23 @@ pub mod explicit_draughting {
             &self.representation_context
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct GlobalUnitAssignedContext {
         pub units: Vec<Unit>,
         pub representation_context: RepresentationContext,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Group {
         pub name: Label,
         pub description: Text,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct GroupAssignment {
         pub assigned_group: Group,
     }
     pub trait GroupAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
     impl GroupAssignmentAny for GroupAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct GroupRelationship {
         pub name: Label,
         pub description: Text,
@@ -1521,13 +1521,13 @@ pub mod explicit_draughting {
         }
     }
     impl ConicAny for Hyperbola {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Hyperbola {
         pub semi_axis: PositiveLengthMeasure,
         pub semi_imag_axis: PositiveLengthMeasure,
         pub conic: Box<dyn ConicAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Invisibility {
         pub invisible_items: Vec<InvisibleItem>,
     }
@@ -1537,7 +1537,7 @@ pub mod explicit_draughting {
             &self.annotation_curve_occurrence
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct LeaderCurve {
         pub annotation_curve_occurrence: AnnotationCurveOccurrence,
     }
@@ -1547,7 +1547,7 @@ pub mod explicit_draughting {
             &self.draughting_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct LeaderDirectedCallout {
         pub draughting_callout: DraughtingCallout,
     }
@@ -1557,7 +1557,7 @@ pub mod explicit_draughting {
             &self.leader_directed_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct LeaderDirectedDimension {
         pub leader_directed_callout: LeaderDirectedCallout,
     }
@@ -1567,7 +1567,7 @@ pub mod explicit_draughting {
             &self.terminator_symbol
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct LeaderTerminator {
         pub terminator_symbol: TerminatorSymbol,
     }
@@ -1578,7 +1578,7 @@ pub mod explicit_draughting {
         }
     }
     impl MeasureWithUnitAny for LengthMeasureWithUnit {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct LengthMeasureWithUnit {
         pub measure_with_unit: Box<dyn MeasureWithUnitAny>,
     }
@@ -1589,7 +1589,7 @@ pub mod explicit_draughting {
         }
     }
     impl NamedUnitAny for LengthUnit {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct LengthUnit {
         pub named_unit: Box<dyn NamedUnitAny>,
     }
@@ -1600,7 +1600,7 @@ pub mod explicit_draughting {
         }
     }
     impl CurveAny for Line {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Line {
         pub pnt: CartesianPoint,
         pub dir: Vector,
@@ -1612,7 +1612,7 @@ pub mod explicit_draughting {
             &self.dimension_curve_directed_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct LinearDimension {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
     }
@@ -1622,20 +1622,20 @@ pub mod explicit_draughting {
             &self.representation_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct MappedItem {
         pub mapping_source: RepresentationMap,
         pub mapping_target: RepresentationItem,
         pub representation_item: RepresentationItem,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct MeasureWithUnit {
         pub value_component: MeasureValue,
         pub unit_component: Unit,
     }
     pub trait MeasureWithUnitAny: ::std::any::Any + ::std::fmt::Debug {}
     impl MeasureWithUnitAny for MeasureWithUnit {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct NamedUnit {
         pub dimensions: DimensionalExponents,
     }
@@ -1648,7 +1648,7 @@ pub mod explicit_draughting {
         }
     }
     impl CurveAny for OffsetCurve2D {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct OffsetCurve2D {
         pub basis_curve: Box<dyn CurveAny>,
         pub distance: LengthMeasure,
@@ -1662,7 +1662,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for OneDirectionRepeatFactor {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct OneDirectionRepeatFactor {
         pub repeat_factor: Vector,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
@@ -1673,24 +1673,24 @@ pub mod explicit_draughting {
             &self.projection_directed_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct OrdinateDimension {
         pub projection_directed_callout: ProjectionDirectedCallout,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Organization {
         pub id: Option<Identifier>,
         pub name: Label,
         pub description: Text,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct OrganizationAssignment {
         pub assigned_organization: Organization,
         pub role: OrganizationRole,
     }
     pub trait OrganizationAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
     impl OrganizationAssignmentAny for OrganizationAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct OrganizationRole {
         pub name: Label,
     }
@@ -1700,7 +1700,7 @@ pub mod explicit_draughting {
             &self.address
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct OrganizationalAddress {
         pub organizations: Vec<Organization>,
         pub description: Text,
@@ -1713,12 +1713,12 @@ pub mod explicit_draughting {
         }
     }
     impl ConicAny for Parabola {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Parabola {
         pub focal_dist: LengthMeasure,
         pub conic: Box<dyn ConicAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Person {
         pub id: Identifier,
         pub last_name: Option<Label>,
@@ -1727,30 +1727,30 @@ pub mod explicit_draughting {
         pub prefix_titles: Option<Vec<Label>>,
         pub suffix_titles: Option<Vec<Label>>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PersonAndOrganization {
         pub the_person: Person,
         pub the_organization: Organization,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PersonAndOrganizationAssignment {
         pub assigned_person_and_organization: PersonAndOrganization,
         pub role: PersonAndOrganizationRole,
     }
     pub trait PersonAndOrganizationAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
     impl PersonAndOrganizationAssignmentAny for PersonAndOrganizationAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PersonAndOrganizationRole {
         pub name: Label,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PersonAssignment {
         pub assigned_person: Person,
         pub role: PersonRole,
     }
     pub trait PersonAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
     impl PersonAssignmentAny for PersonAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PersonRole {
         pub name: Label,
     }
@@ -1760,7 +1760,7 @@ pub mod explicit_draughting {
             &self.address
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PersonalAddress {
         pub people: Vec<Person>,
         pub description: Text,
@@ -1773,7 +1773,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for Placement {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Placement {
         pub location: CartesianPoint,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
@@ -1786,7 +1786,7 @@ pub mod explicit_draughting {
             &self.planar_extent
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PlanarBox {
         pub placement: Axis2Placement,
         pub planar_extent: PlanarExtent,
@@ -1798,7 +1798,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for PlanarExtent {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PlanarExtent {
         pub size_in_x: LengthMeasure,
         pub size_in_y: LengthMeasure,
@@ -1811,7 +1811,7 @@ pub mod explicit_draughting {
         }
     }
     impl MeasureWithUnitAny for PlaneAngleMeasureWithUnit {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PlaneAngleMeasureWithUnit {
         pub measure_with_unit: Box<dyn MeasureWithUnitAny>,
     }
@@ -1822,7 +1822,7 @@ pub mod explicit_draughting {
         }
     }
     impl NamedUnitAny for PlaneAngleUnit {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PlaneAngleUnit {
         pub named_unit: Box<dyn NamedUnitAny>,
     }
@@ -1833,7 +1833,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for Point {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Point {
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
@@ -1846,7 +1846,7 @@ pub mod explicit_draughting {
         }
     }
     impl PointAny for PointOnCurve {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PointOnCurve {
         pub basis_curve: Box<dyn CurveAny>,
         pub point_parameter: ParameterValue,
@@ -1859,12 +1859,12 @@ pub mod explicit_draughting {
         }
     }
     impl BoundedCurveAny for Polyline {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Polyline {
         pub points: Vec<CartesianPoint>,
         pub bounded_curve: Box<dyn BoundedCurveAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedColour {
         pub pre_defined_item: PreDefinedItem,
         pub colour: Colour,
@@ -1875,7 +1875,7 @@ pub mod explicit_draughting {
             &self.pre_defined_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedCurveFont {
         pub pre_defined_item: PreDefinedItem,
     }
@@ -1885,7 +1885,7 @@ pub mod explicit_draughting {
             &self.pre_defined_symbol
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedDimensionSymbol {
         pub pre_defined_symbol: PreDefinedSymbol,
     }
@@ -1895,11 +1895,11 @@ pub mod explicit_draughting {
             &self.pre_defined_symbol
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedGeometricalToleranceSymbol {
         pub pre_defined_symbol: PreDefinedSymbol,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedItem {
         pub name: Label,
     }
@@ -1909,7 +1909,7 @@ pub mod explicit_draughting {
             &self.pre_defined_symbol
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedPointMarkerSymbol {
         pub pre_defined_symbol: PreDefinedSymbol,
     }
@@ -1919,7 +1919,7 @@ pub mod explicit_draughting {
             &self.pre_defined_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedSymbol {
         pub pre_defined_item: PreDefinedItem,
     }
@@ -1929,7 +1929,7 @@ pub mod explicit_draughting {
             &self.pre_defined_symbol
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedTerminatorSymbol {
         pub pre_defined_symbol: PreDefinedSymbol,
     }
@@ -1939,7 +1939,7 @@ pub mod explicit_draughting {
             &self.pre_defined_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedTextFont {
         pub pre_defined_item: PreDefinedItem,
     }
@@ -1949,17 +1949,17 @@ pub mod explicit_draughting {
             &self.presentation_representation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PresentationArea {
         pub presentation_representation: PresentationRepresentation,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PresentationLayerAssignment {
         pub name: Label,
         pub description: Text,
         pub assigned_items: Vec<LayeredItem>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PresentationLayerUsage {
         pub assignment: PresentationLayerAssignment,
         pub presentation: PresentationRepresentation,
@@ -1970,18 +1970,18 @@ pub mod explicit_draughting {
             &self.representation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PresentationRepresentation {
         pub representation: Representation,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PresentationSet {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PresentationSize {
         pub unit: PresentationSizeAssignmentSelect,
         pub size: PlanarBox,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PresentationStyleAssignment {
         pub styles: Vec<PresentationStyleSelect>,
     }
@@ -1991,7 +1991,7 @@ pub mod explicit_draughting {
             &self.presentation_style_assignment
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PresentationStyleByContext {
         pub style_context: StyleContextSelect,
         pub presentation_style_assignment: PresentationStyleAssignment,
@@ -2002,20 +2002,20 @@ pub mod explicit_draughting {
             &self.presentation_representation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PresentationView {
         pub presentation_representation: PresentationRepresentation,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PresentedItem {}
     pub trait PresentedItemAny: ::std::any::Any + ::std::fmt::Debug {}
     impl PresentedItemAny for PresentedItem {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PresentedItemRepresentation {
         pub presentation: PresentationRepresentationSelect,
         pub item: Box<dyn PresentedItemAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Product {
         pub id: Identifier,
         pub name: Label,
@@ -2029,12 +2029,12 @@ pub mod explicit_draughting {
         }
     }
     impl ApplicationContextElementAny for ProductContext {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ProductContext {
         pub discipline_type: Label,
         pub application_context_element: Box<dyn ApplicationContextElementAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ProductDefinition {
         pub id: Identifier,
         pub description: Text,
@@ -2048,12 +2048,12 @@ pub mod explicit_draughting {
         }
     }
     impl ApplicationContextElementAny for ProductDefinitionContext {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ProductDefinitionContext {
         pub life_cycle_stage: Label,
         pub application_context_element: Box<dyn ApplicationContextElementAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ProductDefinitionFormation {
         pub id: Identifier,
         pub description: Text,
@@ -2065,7 +2065,7 @@ pub mod explicit_draughting {
             &self.property_definition
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ProductDefinitionShape {
         pub property_definition: PropertyDefinition,
     }
@@ -2075,7 +2075,7 @@ pub mod explicit_draughting {
             &self.annotation_curve_occurrence
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ProjectionCurve {
         pub annotation_curve_occurrence: AnnotationCurveOccurrence,
     }
@@ -2085,17 +2085,17 @@ pub mod explicit_draughting {
             &self.draughting_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ProjectionDirectedCallout {
         pub draughting_callout: DraughtingCallout,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PropertyDefinition {
         pub name: Label,
         pub description: Text,
         pub definition: CharacterizedDefinition,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct PropertyDefinitionRepresentation {
         pub definition: PropertyDefinition,
         pub used_representation: Representation,
@@ -2107,7 +2107,7 @@ pub mod explicit_draughting {
         }
     }
     impl BSplineCurveAny for QuasiUniformCurve {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct QuasiUniformCurve {
         pub b_spline_curve: Box<dyn BSplineCurveAny>,
     }
@@ -2117,7 +2117,7 @@ pub mod explicit_draughting {
             &self.dimension_curve_directed_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct RadiusDimension {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
     }
@@ -2128,44 +2128,44 @@ pub mod explicit_draughting {
         }
     }
     impl BSplineCurveAny for RationalBSplineCurve {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct RationalBSplineCurve {
         pub weights_data: Vec<f64>,
         pub b_spline_curve: Box<dyn BSplineCurveAny>,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Representation {
         pub name: Label,
         pub items: Vec<RepresentationItem>,
         pub context_of_items: RepresentationContext,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct RepresentationContext {
         pub context_identifier: Identifier,
         pub context_type: Text,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct RepresentationItem {
         pub name: Label,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct RepresentationMap {
         pub mapping_origin: RepresentationItem,
         pub mapped_representation: Representation,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct SecurityClassification {
         pub name: Label,
         pub purpose: Text,
         pub security_level: SecurityClassificationLevel,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct SecurityClassificationAssignment {
         pub assigned_security_classification: SecurityClassification,
     }
     pub trait SecurityClassificationAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
     impl SecurityClassificationAssignmentAny for SecurityClassificationAssignment {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct SecurityClassificationLevel {
         pub name: Label,
     }
@@ -2175,7 +2175,7 @@ pub mod explicit_draughting {
             &self.property_definition_representation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ShapeDefinitionRepresentation {
         pub property_definition_representation: PropertyDefinitionRepresentation,
     }
@@ -2185,7 +2185,7 @@ pub mod explicit_draughting {
             &self.representation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct ShapeRepresentation {
         pub representation: Representation,
     }
@@ -2196,7 +2196,7 @@ pub mod explicit_draughting {
         }
     }
     impl NamedUnitAny for SiUnit {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct SiUnit {
         pub prefix: Option<SiPrefix>,
         pub name: SiUnitName,
@@ -2208,7 +2208,7 @@ pub mod explicit_draughting {
             &self.draughting_callout
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct StructuredDimensionCallout {
         pub draughting_callout: DraughtingCallout,
     }
@@ -2218,13 +2218,13 @@ pub mod explicit_draughting {
             &self.representation_item
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct StyledItem {
         pub styles: Vec<PresentationStyleAssignment>,
         pub item: RepresentationItem,
         pub representation_item: RepresentationItem,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct SymbolColour {
         pub colour_of_symbol: Colour,
     }
@@ -2234,7 +2234,7 @@ pub mod explicit_draughting {
             &self.representation
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct SymbolRepresentation {
         pub representation: Representation,
     }
@@ -2244,11 +2244,11 @@ pub mod explicit_draughting {
             &self.representation_map
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct SymbolRepresentationMap {
         pub representation_map: RepresentationMap,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct SymbolStyle {
         pub name: Label,
         pub style_of_symbol: SymbolStyleSelect,
@@ -2260,7 +2260,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for SymbolTarget {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct SymbolTarget {
         pub placement: Axis2Placement,
         pub x_scale: PositiveRatioMeasure,
@@ -2273,7 +2273,7 @@ pub mod explicit_draughting {
             &self.annotation_symbol_occurrence
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TerminatorSymbol {
         pub annotated_curve: AnnotationCurveOccurrence,
         pub annotation_symbol_occurrence: AnnotationSymbolOccurrence,
@@ -2285,7 +2285,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for TextLiteral {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TextLiteral {
         pub literal: PresentableText,
         pub placement: Axis2Placement,
@@ -2300,7 +2300,7 @@ pub mod explicit_draughting {
             &self.text_literal
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TextLiteralWithAssociatedCurves {
         pub associated_curves: Vec<Box<dyn CurveAny>>,
         pub text_literal: TextLiteral,
@@ -2311,7 +2311,7 @@ pub mod explicit_draughting {
             &self.text_literal
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TextLiteralWithBlankingBox {
         pub blanking: PlanarBox,
         pub text_literal: TextLiteral,
@@ -2322,7 +2322,7 @@ pub mod explicit_draughting {
             &self.text_literal
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TextLiteralWithDelineation {
         pub delineation: TextDelineation,
         pub text_literal: TextLiteral,
@@ -2333,17 +2333,17 @@ pub mod explicit_draughting {
             &self.text_literal
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TextLiteralWithExtent {
         pub extent: PlanarExtent,
         pub text_literal: TextLiteral,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TextStyle {
         pub name: Label,
         pub character_appearance: CharacterStyleSelect,
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TextStyleForDefinedFont {
         pub text_colour: Colour,
     }
@@ -2353,7 +2353,7 @@ pub mod explicit_draughting {
             &self.text_style
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TextStyleWithBoxCharacteristics {
         pub characteristics: Vec<BoxCharacteristicSelect>,
         pub text_style: TextStyle,
@@ -2364,7 +2364,7 @@ pub mod explicit_draughting {
             &self.text_style
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TextStyleWithMirror {
         pub mirror_placement: Axis2Placement,
         pub text_style: TextStyle,
@@ -2376,7 +2376,7 @@ pub mod explicit_draughting {
         }
     }
     impl BoundedCurveAny for TrimmedCurve {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TrimmedCurve {
         pub basis_curve: Box<dyn CurveAny>,
         pub trim_1: Vec<TrimmingSelect>,
@@ -2391,7 +2391,7 @@ pub mod explicit_draughting {
             &self.one_direction_repeat_factor
         }
     }
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct TwoDirectionRepeatFactor {
         pub second_repeat_factor: Vector,
         pub one_direction_repeat_factor: OneDirectionRepeatFactor,
@@ -2403,7 +2403,7 @@ pub mod explicit_draughting {
         }
     }
     impl BSplineCurveAny for UniformCurve {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct UniformCurve {
         pub b_spline_curve: Box<dyn BSplineCurveAny>,
     }
@@ -2414,7 +2414,7 @@ pub mod explicit_draughting {
         }
     }
     impl GeometricRepresentationItemAny for Vector {}
-    #[derive(Clone, Debug, PartialEq, derive_new :: new)]
+    #[derive(Debug, derive_new :: new)]
     pub struct Vector {
         pub orientation: Direction,
         pub magnitude: LengthMeasure,

--- a/ruststep/src/ap201.rs
+++ b/ruststep/src/ap201.rs
@@ -376,6 +376,7 @@ pub mod explicit_draughting {
             &self.annotation_occurrence
         }
     }
+    impl AnnotationOccurrenceAny for AnnotationCurveOccurrence {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct AnnotationCurveOccurrence {
         pub annotation_occurrence: AnnotationOccurrence,
@@ -386,6 +387,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for AnnotationFillArea {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct AnnotationFillArea {
         pub boundaries: Vec<Curve>,
@@ -397,6 +399,7 @@ pub mod explicit_draughting {
             &self.annotation_occurrence
         }
     }
+    impl AnnotationOccurrenceAny for AnnotationFillAreaOccurrence {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct AnnotationFillAreaOccurrence {
         pub fill_style_target: Point,
@@ -440,6 +443,7 @@ pub mod explicit_draughting {
             &self.annotation_occurrence
         }
     }
+    impl AnnotationOccurrenceAny for AnnotationSymbolOccurrence {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct AnnotationSymbolOccurrence {
         pub annotation_occurrence: AnnotationOccurrence,
@@ -460,6 +464,7 @@ pub mod explicit_draughting {
             &self.annotation_occurrence
         }
     }
+    impl AnnotationOccurrenceAny for AnnotationTextOccurrence {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct AnnotationTextOccurrence {
         pub annotation_occurrence: AnnotationOccurrence,
@@ -523,6 +528,7 @@ pub mod explicit_draughting {
             &self.placement
         }
     }
+    impl PlacementAny for Axis2Placement2D {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Axis2Placement2D {
         pub ref_direction: Option<Direction>,
@@ -534,6 +540,7 @@ pub mod explicit_draughting {
             &self.bounded_curve
         }
     }
+    impl BoundedCurveAny for BSplineCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct BSplineCurve {
         pub degree: i64,
@@ -551,6 +558,7 @@ pub mod explicit_draughting {
             &self.b_spline_curve
         }
     }
+    impl BSplineCurveAny for BSplineCurveWithKnots {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct BSplineCurveWithKnots {
         pub knot_multiplicities: Vec<i64>,
@@ -564,6 +572,7 @@ pub mod explicit_draughting {
             &self.b_spline_curve
         }
     }
+    impl BSplineCurveAny for BezierCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct BezierCurve {
         pub b_spline_curve: BSplineCurve,
@@ -574,6 +583,7 @@ pub mod explicit_draughting {
             &self.curve
         }
     }
+    impl CurveAny for BoundedCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct BoundedCurve {
         pub curve: Curve,
@@ -586,6 +596,7 @@ pub mod explicit_draughting {
             &self.date
         }
     }
+    impl DateAny for CalendarDate {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct CalendarDate {
         pub day_component: DayInMonthNumber,
@@ -618,6 +629,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for CameraModel {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct CameraModel {
         pub geometric_representation_item: GeometricRepresentationItem,
@@ -630,6 +642,7 @@ pub mod explicit_draughting {
             &self.camera_model
         }
     }
+    impl CameraModelAny for CameraModelD2 {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct CameraModelD2 {
         pub view_window: PlanarBox,
@@ -652,6 +665,7 @@ pub mod explicit_draughting {
             &self.point
         }
     }
+    impl PointAny for CartesianPoint {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct CartesianPoint {
         pub coordinates: Vec<LengthMeasure>,
@@ -663,6 +677,7 @@ pub mod explicit_draughting {
             &self.conic
         }
     }
+    impl ConicAny for Circle {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Circle {
         pub radius: PositiveLengthMeasure,
@@ -700,6 +715,7 @@ pub mod explicit_draughting {
             &self.bounded_curve
         }
     }
+    impl BoundedCurveAny for CompositeCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct CompositeCurve {
         pub segments: Vec<CompositeCurveSegment>,
@@ -718,6 +734,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for CompositeText {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct CompositeText {
         pub collected_text: Vec<TextOrCharacter>,
@@ -762,6 +779,7 @@ pub mod explicit_draughting {
             &self.curve
         }
     }
+    impl CurveAny for Conic {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Conic {
         pub position: Axis2Placement,
@@ -802,6 +820,7 @@ pub mod explicit_draughting {
             &self.named_unit
         }
     }
+    impl NamedUnitAny for ConversionBasedUnit {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ConversionBasedUnit {
         pub name: Label,
@@ -814,6 +833,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for Curve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Curve {
         pub geometric_representation_item: GeometricRepresentationItem,
@@ -879,6 +899,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for DefinedSymbol {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DefinedSymbol {
         pub definition: DefinedSymbolSelect,
@@ -972,6 +993,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for Direction {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Direction {
         pub direction_ratios: Vec<f64>,
@@ -1001,6 +1023,7 @@ pub mod explicit_draughting {
             &self.annotation_occurrence
         }
     }
+    impl AnnotationOccurrenceAny for DraughtingAnnotationOccurrence {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingAnnotationOccurrence {
         pub annotation_occurrence: AnnotationOccurrence,
@@ -1011,6 +1034,7 @@ pub mod explicit_draughting {
             &self.approval_assignment
         }
     }
+    impl ApprovalAssignmentAny for DraughtingApprovalAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingApprovalAssignment {
         pub approved_items: Vec<ApprovedItem>,
@@ -1022,6 +1046,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for DraughtingCallout {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingCallout {
         pub contents: Vec<DraughtingCalloutElement>,
@@ -1040,6 +1065,7 @@ pub mod explicit_draughting {
             &self.contract_assignment
         }
     }
+    impl ContractAssignmentAny for DraughtingContractAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingContractAssignment {
         pub items: Vec<ContractedItem>,
@@ -1071,6 +1097,7 @@ pub mod explicit_draughting {
             &self.group_assignment
         }
     }
+    impl GroupAssignmentAny for DraughtingGroupAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingGroupAssignment {
         pub items: Vec<DraughtingGroupedItem>,
@@ -1092,6 +1119,7 @@ pub mod explicit_draughting {
             &self.organization_assignment
         }
     }
+    impl OrganizationAssignmentAny for DraughtingOrganizationAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingOrganizationAssignment {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
@@ -1103,6 +1131,7 @@ pub mod explicit_draughting {
             &self.person_and_organization_assignment
         }
     }
+    impl PersonAndOrganizationAssignmentAny for DraughtingPersonAndOrganizationAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingPersonAndOrganizationAssignment {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
@@ -1114,6 +1143,7 @@ pub mod explicit_draughting {
             &self.person_assignment
         }
     }
+    impl PersonAssignmentAny for DraughtingPersonAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingPersonAssignment {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
@@ -1155,6 +1185,7 @@ pub mod explicit_draughting {
             &self.presented_item
         }
     }
+    impl PresentedItemAny for DraughtingPresentedItem {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingPresentedItem {
         pub items: Vec<DraughtingPresentedItemSelect>,
@@ -1166,6 +1197,7 @@ pub mod explicit_draughting {
             &self.security_classification_assignment
         }
     }
+    impl SecurityClassificationAssignmentAny for DraughtingSecurityClassificationAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingSecurityClassificationAssignment {
         pub assigned_items: Vec<ClassifiedItem>,
@@ -1177,6 +1209,7 @@ pub mod explicit_draughting {
             &self.document_reference
         }
     }
+    impl DocumentReferenceAny for DraughtingSpecificationReference {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingSpecificationReference {
         pub specified_items: Vec<SpecifiedItem>,
@@ -1274,6 +1307,7 @@ pub mod explicit_draughting {
             &self.conic
         }
     }
+    impl ConicAny for Ellipse {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Ellipse {
         pub semi_axis_1: PositiveLengthMeasure,
@@ -1294,6 +1328,7 @@ pub mod explicit_draughting {
     pub struct ExternallyDefinedCurveFont {
         pub externally_defined_item: ExternallyDefinedItem,
     }
+    impl GeometricRepresentationItemAny for ExternallyDefinedHatchStyle {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ExternallyDefinedHatchStyle {
         pub externally_defined_item: ExternallyDefinedItem,
@@ -1324,6 +1359,7 @@ pub mod explicit_draughting {
     pub struct ExternallyDefinedTextFont {
         pub externally_defined_item: ExternallyDefinedItem,
     }
+    impl GeometricRepresentationItemAny for ExternallyDefinedTileStyle {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ExternallyDefinedTileStyle {
         pub externally_defined_item: ExternallyDefinedItem,
@@ -1345,6 +1381,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for FillAreaStyleHatching {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct FillAreaStyleHatching {
         pub hatch_line_appearance: CurveStyle,
@@ -1360,6 +1397,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for FillAreaStyleTileSymbolWithStyle {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct FillAreaStyleTileSymbolWithStyle {
         pub symbol: AnnotationSymbolOccurrence,
@@ -1371,6 +1409,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for FillAreaStyleTiles {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct FillAreaStyleTiles {
         pub tiling_pattern: TwoDirectionRepeatFactor,
@@ -1384,6 +1423,7 @@ pub mod explicit_draughting {
             &self.geometric_set
         }
     }
+    impl GeometricSetAny for GeometricCurveSet {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct GeometricCurveSet {
         pub geometric_set: GeometricSet,
@@ -1417,6 +1457,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for GeometricSet {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct GeometricSet {
         pub elements: Vec<GeometricSetSelect>,
@@ -1479,6 +1520,7 @@ pub mod explicit_draughting {
             &self.conic
         }
     }
+    impl ConicAny for Hyperbola {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Hyperbola {
         pub semi_axis: PositiveLengthMeasure,
@@ -1535,6 +1577,7 @@ pub mod explicit_draughting {
             &self.measure_with_unit
         }
     }
+    impl MeasureWithUnitAny for LengthMeasureWithUnit {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct LengthMeasureWithUnit {
         pub measure_with_unit: MeasureWithUnit,
@@ -1545,6 +1588,7 @@ pub mod explicit_draughting {
             &self.named_unit
         }
     }
+    impl NamedUnitAny for LengthUnit {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct LengthUnit {
         pub named_unit: NamedUnit,
@@ -1555,6 +1599,7 @@ pub mod explicit_draughting {
             &self.curve
         }
     }
+    impl CurveAny for Line {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Line {
         pub pnt: CartesianPoint,
@@ -1602,6 +1647,7 @@ pub mod explicit_draughting {
             &self.curve
         }
     }
+    impl CurveAny for OffsetCurve2D {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct OffsetCurve2D {
         pub basis_curve: Curve,
@@ -1615,6 +1661,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for OneDirectionRepeatFactor {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct OneDirectionRepeatFactor {
         pub repeat_factor: Vector,
@@ -1665,6 +1712,7 @@ pub mod explicit_draughting {
             &self.conic
         }
     }
+    impl ConicAny for Parabola {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Parabola {
         pub focal_dist: LengthMeasure,
@@ -1724,6 +1772,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for Placement {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Placement {
         pub location: CartesianPoint,
@@ -1748,6 +1797,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for PlanarExtent {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PlanarExtent {
         pub size_in_x: LengthMeasure,
@@ -1760,6 +1810,7 @@ pub mod explicit_draughting {
             &self.measure_with_unit
         }
     }
+    impl MeasureWithUnitAny for PlaneAngleMeasureWithUnit {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PlaneAngleMeasureWithUnit {
         pub measure_with_unit: MeasureWithUnit,
@@ -1770,6 +1821,7 @@ pub mod explicit_draughting {
             &self.named_unit
         }
     }
+    impl NamedUnitAny for PlaneAngleUnit {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PlaneAngleUnit {
         pub named_unit: NamedUnit,
@@ -1780,6 +1832,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for Point {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Point {
         pub geometric_representation_item: GeometricRepresentationItem,
@@ -1792,6 +1845,7 @@ pub mod explicit_draughting {
             &self.point
         }
     }
+    impl PointAny for PointOnCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PointOnCurve {
         pub basis_curve: Curve,
@@ -1804,6 +1858,7 @@ pub mod explicit_draughting {
             &self.bounded_curve
         }
     }
+    impl BoundedCurveAny for Polyline {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Polyline {
         pub points: Vec<CartesianPoint>,
@@ -1973,6 +2028,7 @@ pub mod explicit_draughting {
             &self.application_context_element
         }
     }
+    impl ApplicationContextElementAny for ProductContext {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ProductContext {
         pub discipline_type: Label,
@@ -1991,6 +2047,7 @@ pub mod explicit_draughting {
             &self.application_context_element
         }
     }
+    impl ApplicationContextElementAny for ProductDefinitionContext {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ProductDefinitionContext {
         pub life_cycle_stage: Label,
@@ -2049,6 +2106,7 @@ pub mod explicit_draughting {
             &self.b_spline_curve
         }
     }
+    impl BSplineCurveAny for QuasiUniformCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct QuasiUniformCurve {
         pub b_spline_curve: BSplineCurve,
@@ -2069,6 +2127,7 @@ pub mod explicit_draughting {
             &self.b_spline_curve
         }
     }
+    impl BSplineCurveAny for RationalBSplineCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct RationalBSplineCurve {
         pub weights_data: Vec<f64>,
@@ -2136,6 +2195,7 @@ pub mod explicit_draughting {
             &self.named_unit
         }
     }
+    impl NamedUnitAny for SiUnit {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct SiUnit {
         pub prefix: Option<SiPrefix>,
@@ -2199,6 +2259,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for SymbolTarget {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct SymbolTarget {
         pub placement: Axis2Placement,
@@ -2223,6 +2284,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for TextLiteral {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct TextLiteral {
         pub literal: PresentableText,
@@ -2313,6 +2375,7 @@ pub mod explicit_draughting {
             &self.bounded_curve
         }
     }
+    impl BoundedCurveAny for TrimmedCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct TrimmedCurve {
         pub basis_curve: Curve,
@@ -2339,6 +2402,7 @@ pub mod explicit_draughting {
             &self.b_spline_curve
         }
     }
+    impl BSplineCurveAny for UniformCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct UniformCurve {
         pub b_spline_curve: BSplineCurve,
@@ -2349,6 +2413,7 @@ pub mod explicit_draughting {
             &self.geometric_representation_item
         }
     }
+    impl GeometricRepresentationItemAny for Vector {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Vector {
         pub orientation: Direction,

--- a/ruststep/src/ap201.rs
+++ b/ruststep/src/ap201.rs
@@ -360,32 +360,14 @@ pub mod explicit_draughting {
         pub electronic_mail_address: Option<Label>,
         pub telex_number: Option<Label>,
     }
-    impl ::std::ops::Deref for AngularDimension {
-        type Target = DimensionCurveDirectedCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.dimension_curve_directed_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct AngularDimension {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
-    }
-    impl ::std::ops::Deref for AnnotationCurveOccurrence {
-        type Target = Box<dyn AnnotationOccurrenceAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.annotation_occurrence
-        }
     }
     impl AnnotationOccurrenceAny for AnnotationCurveOccurrence {}
     #[derive(Debug, derive_new :: new)]
     pub struct AnnotationCurveOccurrence {
         pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
-    }
-    impl ::std::ops::Deref for AnnotationFillArea {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for AnnotationFillArea {}
     #[derive(Debug, derive_new :: new)]
@@ -393,23 +375,11 @@ pub mod explicit_draughting {
         pub boundaries: Vec<Box<dyn CurveAny>>,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    impl ::std::ops::Deref for AnnotationFillAreaOccurrence {
-        type Target = Box<dyn AnnotationOccurrenceAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.annotation_occurrence
-        }
-    }
     impl AnnotationOccurrenceAny for AnnotationFillAreaOccurrence {}
     #[derive(Debug, derive_new :: new)]
     pub struct AnnotationFillAreaOccurrence {
         pub fill_style_target: Box<dyn PointAny>,
         pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
-    }
-    impl ::std::ops::Deref for AnnotationOccurrence {
-        type Target = StyledItem;
-        fn deref(&self) -> &Self::Target {
-            &self.styled_item
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct AnnotationOccurrence {
@@ -417,52 +387,22 @@ pub mod explicit_draughting {
     }
     pub trait AnnotationOccurrenceAny: ::std::any::Any + ::std::fmt::Debug {}
     impl AnnotationOccurrenceAny for AnnotationOccurrence {}
-    impl ::std::ops::Deref for AnnotationSubfigureOccurrence {
-        type Target = AnnotationSymbolOccurrence;
-        fn deref(&self) -> &Self::Target {
-            &self.annotation_symbol_occurrence
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct AnnotationSubfigureOccurrence {
         pub annotation_symbol_occurrence: AnnotationSymbolOccurrence,
     }
-    impl ::std::ops::Deref for AnnotationSymbol {
-        type Target = MappedItem;
-        fn deref(&self) -> &Self::Target {
-            &self.mapped_item
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct AnnotationSymbol {
         pub mapped_item: MappedItem,
-    }
-    impl ::std::ops::Deref for AnnotationSymbolOccurrence {
-        type Target = Box<dyn AnnotationOccurrenceAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.annotation_occurrence
-        }
     }
     impl AnnotationOccurrenceAny for AnnotationSymbolOccurrence {}
     #[derive(Debug, derive_new :: new)]
     pub struct AnnotationSymbolOccurrence {
         pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
     }
-    impl ::std::ops::Deref for AnnotationText {
-        type Target = MappedItem;
-        fn deref(&self) -> &Self::Target {
-            &self.mapped_item
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct AnnotationText {
         pub mapped_item: MappedItem,
-    }
-    impl ::std::ops::Deref for AnnotationTextOccurrence {
-        type Target = Box<dyn AnnotationOccurrenceAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.annotation_occurrence
-        }
     }
     impl AnnotationOccurrenceAny for AnnotationTextOccurrence {}
     #[derive(Debug, derive_new :: new)]
@@ -522,23 +462,11 @@ pub mod explicit_draughting {
         pub area: PresentationArea,
         pub in_set: PresentationSet,
     }
-    impl ::std::ops::Deref for Axis2Placement2D {
-        type Target = Box<dyn PlacementAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.placement
-        }
-    }
     impl PlacementAny for Axis2Placement2D {}
     #[derive(Debug, derive_new :: new)]
     pub struct Axis2Placement2D {
         pub ref_direction: Option<Direction>,
         pub placement: Box<dyn PlacementAny>,
-    }
-    impl ::std::ops::Deref for BSplineCurve {
-        type Target = Box<dyn BoundedCurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.bounded_curve
-        }
     }
     impl BoundedCurveAny for BSplineCurve {}
     #[derive(Debug, derive_new :: new)]
@@ -552,12 +480,6 @@ pub mod explicit_draughting {
     }
     pub trait BSplineCurveAny: ::std::any::Any + ::std::fmt::Debug {}
     impl BSplineCurveAny for BSplineCurve {}
-    impl ::std::ops::Deref for BSplineCurveWithKnots {
-        type Target = Box<dyn BSplineCurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.b_spline_curve
-        }
-    }
     impl BSplineCurveAny for BSplineCurveWithKnots {}
     #[derive(Debug, derive_new :: new)]
     pub struct BSplineCurveWithKnots {
@@ -566,22 +488,10 @@ pub mod explicit_draughting {
         pub knot_spec: KnotType,
         pub b_spline_curve: Box<dyn BSplineCurveAny>,
     }
-    impl ::std::ops::Deref for BezierCurve {
-        type Target = Box<dyn BSplineCurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.b_spline_curve
-        }
-    }
     impl BSplineCurveAny for BezierCurve {}
     #[derive(Debug, derive_new :: new)]
     pub struct BezierCurve {
         pub b_spline_curve: Box<dyn BSplineCurveAny>,
-    }
-    impl ::std::ops::Deref for BoundedCurve {
-        type Target = Box<dyn CurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.curve
-        }
     }
     impl CurveAny for BoundedCurve {}
     #[derive(Debug, derive_new :: new)]
@@ -590,12 +500,6 @@ pub mod explicit_draughting {
     }
     pub trait BoundedCurveAny: ::std::any::Any + ::std::fmt::Debug {}
     impl BoundedCurveAny for BoundedCurve {}
-    impl ::std::ops::Deref for CalendarDate {
-        type Target = Box<dyn DateAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.date
-        }
-    }
     impl DateAny for CalendarDate {}
     #[derive(Debug, derive_new :: new)]
     pub struct CalendarDate {
@@ -603,31 +507,13 @@ pub mod explicit_draughting {
         pub month_component: MonthInYearNumber,
         pub date: Box<dyn DateAny>,
     }
-    impl ::std::ops::Deref for CameraImage {
-        type Target = MappedItem;
-        fn deref(&self) -> &Self::Target {
-            &self.mapped_item
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct CameraImage {
         pub mapped_item: MappedItem,
     }
-    impl ::std::ops::Deref for CameraImage2DWithScale {
-        type Target = CameraImage;
-        fn deref(&self) -> &Self::Target {
-            &self.camera_image
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct CameraImage2DWithScale {
         pub camera_image: CameraImage,
-    }
-    impl ::std::ops::Deref for CameraModel {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for CameraModel {}
     #[derive(Debug, derive_new :: new)]
@@ -636,12 +522,6 @@ pub mod explicit_draughting {
     }
     pub trait CameraModelAny: ::std::any::Any + ::std::fmt::Debug {}
     impl CameraModelAny for CameraModel {}
-    impl ::std::ops::Deref for CameraModelD2 {
-        type Target = Box<dyn CameraModelAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.camera_model
-        }
-    }
     impl CameraModelAny for CameraModelD2 {}
     #[derive(Debug, derive_new :: new)]
     pub struct CameraModelD2 {
@@ -649,33 +529,15 @@ pub mod explicit_draughting {
         pub view_window_clipping: bool,
         pub camera_model: Box<dyn CameraModelAny>,
     }
-    impl ::std::ops::Deref for CameraUsage {
-        type Target = RepresentationMap;
-        fn deref(&self) -> &Self::Target {
-            &self.representation_map
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct CameraUsage {
         pub representation_map: RepresentationMap,
-    }
-    impl ::std::ops::Deref for CartesianPoint {
-        type Target = Box<dyn PointAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.point
-        }
     }
     impl PointAny for CartesianPoint {}
     #[derive(Debug, derive_new :: new)]
     pub struct CartesianPoint {
         pub coordinates: Vec<LengthMeasure>,
         pub point: Box<dyn PointAny>,
-    }
-    impl ::std::ops::Deref for Circle {
-        type Target = Box<dyn ConicAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.conic
-        }
     }
     impl ConicAny for Circle {}
     #[derive(Debug, derive_new :: new)]
@@ -685,12 +547,6 @@ pub mod explicit_draughting {
     }
     #[derive(Debug, derive_new :: new)]
     pub struct Colour {}
-    impl ::std::ops::Deref for ColourRgb {
-        type Target = ColourSpecification;
-        fn deref(&self) -> &Self::Target {
-            &self.colour_specification
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct ColourRgb {
         pub red: f64,
@@ -698,22 +554,10 @@ pub mod explicit_draughting {
         pub blue: f64,
         pub colour_specification: ColourSpecification,
     }
-    impl ::std::ops::Deref for ColourSpecification {
-        type Target = Colour;
-        fn deref(&self) -> &Self::Target {
-            &self.colour
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct ColourSpecification {
         pub name: Colour,
         pub colour: Colour,
-    }
-    impl ::std::ops::Deref for CompositeCurve {
-        type Target = Box<dyn BoundedCurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.bounded_curve
-        }
     }
     impl BoundedCurveAny for CompositeCurve {}
     #[derive(Debug, derive_new :: new)]
@@ -728,56 +572,26 @@ pub mod explicit_draughting {
         pub same_sense: bool,
         pub parent_curve: Box<dyn CurveAny>,
     }
-    impl ::std::ops::Deref for CompositeText {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
-    }
     impl GeometricRepresentationItemAny for CompositeText {}
     #[derive(Debug, derive_new :: new)]
     pub struct CompositeText {
         pub collected_text: Vec<TextOrCharacter>,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    impl ::std::ops::Deref for CompositeTextWithAssociatedCurves {
-        type Target = CompositeText;
-        fn deref(&self) -> &Self::Target {
-            &self.composite_text
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct CompositeTextWithAssociatedCurves {
         pub associated_curves: Vec<Box<dyn CurveAny>>,
         pub composite_text: CompositeText,
-    }
-    impl ::std::ops::Deref for CompositeTextWithBlankingBox {
-        type Target = CompositeText;
-        fn deref(&self) -> &Self::Target {
-            &self.composite_text
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct CompositeTextWithBlankingBox {
         pub blanking: PlanarBox,
         pub composite_text: CompositeText,
     }
-    impl ::std::ops::Deref for CompositeTextWithExtent {
-        type Target = CompositeText;
-        fn deref(&self) -> &Self::Target {
-            &self.composite_text
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct CompositeTextWithExtent {
         pub extent: PlanarExtent,
         pub composite_text: CompositeText,
-    }
-    impl ::std::ops::Deref for Conic {
-        type Target = Box<dyn CurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.curve
-        }
     }
     impl CurveAny for Conic {}
     #[derive(Debug, derive_new :: new)]
@@ -787,12 +601,6 @@ pub mod explicit_draughting {
     }
     pub trait ConicAny: ::std::any::Any + ::std::fmt::Debug {}
     impl ConicAny for Conic {}
-    impl ::std::ops::Deref for ContextDependentInvisibility {
-        type Target = Invisibility;
-        fn deref(&self) -> &Self::Target {
-            &self.invisibility
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct ContextDependentInvisibility {
         pub presentation_context: InvisibilityContext,
@@ -814,24 +622,12 @@ pub mod explicit_draughting {
     pub struct ContractType {
         pub description: Label,
     }
-    impl ::std::ops::Deref for ConversionBasedUnit {
-        type Target = Box<dyn NamedUnitAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.named_unit
-        }
-    }
     impl NamedUnitAny for ConversionBasedUnit {}
     #[derive(Debug, derive_new :: new)]
     pub struct ConversionBasedUnit {
         pub name: Label,
         pub conversion_factor: Box<dyn MeasureWithUnitAny>,
         pub named_unit: Box<dyn NamedUnitAny>,
-    }
-    impl ::std::ops::Deref for Curve {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for Curve {}
     #[derive(Debug, derive_new :: new)]
@@ -840,12 +636,6 @@ pub mod explicit_draughting {
     }
     pub trait CurveAny: ::std::any::Any + ::std::fmt::Debug {}
     impl CurveAny for Curve {}
-    impl ::std::ops::Deref for CurveDimension {
-        type Target = DimensionCurveDirectedCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.dimension_curve_directed_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct CurveDimension {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
@@ -873,31 +663,13 @@ pub mod explicit_draughting {
     }
     pub trait DateAny: ::std::any::Any + ::std::fmt::Debug {}
     impl DateAny for Date {}
-    impl ::std::ops::Deref for DatumFeatureCallout {
-        type Target = DraughtingCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DatumFeatureCallout {
         pub draughting_callout: DraughtingCallout,
     }
-    impl ::std::ops::Deref for DatumTargetCallout {
-        type Target = DraughtingCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DatumTargetCallout {
         pub draughting_callout: DraughtingCallout,
-    }
-    impl ::std::ops::Deref for DefinedSymbol {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for DefinedSymbol {}
     #[derive(Debug, derive_new :: new)]
@@ -906,72 +678,30 @@ pub mod explicit_draughting {
         pub target: SymbolTarget,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    impl ::std::ops::Deref for DiameterDimension {
-        type Target = DimensionCurveDirectedCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.dimension_curve_directed_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DiameterDimension {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
-    }
-    impl ::std::ops::Deref for DimensionCalloutComponentRelationship {
-        type Target = DraughtingCalloutRelationship;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_callout_relationship
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct DimensionCalloutComponentRelationship {
         pub draughting_callout_relationship: DraughtingCalloutRelationship,
     }
-    impl ::std::ops::Deref for DimensionCalloutRelationship {
-        type Target = DraughtingCalloutRelationship;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_callout_relationship
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DimensionCalloutRelationship {
         pub draughting_callout_relationship: DraughtingCalloutRelationship,
-    }
-    impl ::std::ops::Deref for DimensionCurve {
-        type Target = AnnotationCurveOccurrence;
-        fn deref(&self) -> &Self::Target {
-            &self.annotation_curve_occurrence
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct DimensionCurve {
         pub annotation_curve_occurrence: AnnotationCurveOccurrence,
     }
-    impl ::std::ops::Deref for DimensionCurveDirectedCallout {
-        type Target = DraughtingCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DimensionCurveDirectedCallout {
         pub draughting_callout: DraughtingCallout,
-    }
-    impl ::std::ops::Deref for DimensionCurveTerminator {
-        type Target = TerminatorSymbol;
-        fn deref(&self) -> &Self::Target {
-            &self.terminator_symbol
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct DimensionCurveTerminator {
         pub role: DimensionExtentUsage,
         pub terminator_symbol: TerminatorSymbol,
-    }
-    impl ::std::ops::Deref for DimensionPair {
-        type Target = DraughtingCalloutRelationship;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_callout_relationship
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct DimensionPair {
@@ -986,12 +716,6 @@ pub mod explicit_draughting {
         pub thermodynamic_temperature_exponent: f64,
         pub amount_of_substance_exponent: f64,
         pub luminous_intensity_exponent: f64,
-    }
-    impl ::std::ops::Deref for Direction {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for Direction {}
     #[derive(Debug, derive_new :: new)]
@@ -1017,34 +741,16 @@ pub mod explicit_draughting {
     pub struct DocumentType {
         pub product_data_type: Label,
     }
-    impl ::std::ops::Deref for DraughtingAnnotationOccurrence {
-        type Target = Box<dyn AnnotationOccurrenceAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.annotation_occurrence
-        }
-    }
     impl AnnotationOccurrenceAny for DraughtingAnnotationOccurrence {}
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingAnnotationOccurrence {
         pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
-    }
-    impl ::std::ops::Deref for DraughtingApprovalAssignment {
-        type Target = Box<dyn ApprovalAssignmentAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.approval_assignment
-        }
     }
     impl ApprovalAssignmentAny for DraughtingApprovalAssignment {}
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingApprovalAssignment {
         pub approved_items: Vec<ApprovedItem>,
         pub approval_assignment: Box<dyn ApprovalAssignmentAny>,
-    }
-    impl ::std::ops::Deref for DraughtingCallout {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for DraughtingCallout {}
     #[derive(Debug, derive_new :: new)]
@@ -1059,43 +765,19 @@ pub mod explicit_draughting {
         pub relating_draughting_callout: DraughtingCallout,
         pub related_draughting_callout: DraughtingCallout,
     }
-    impl ::std::ops::Deref for DraughtingContractAssignment {
-        type Target = Box<dyn ContractAssignmentAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.contract_assignment
-        }
-    }
     impl ContractAssignmentAny for DraughtingContractAssignment {}
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingContractAssignment {
         pub items: Vec<ContractedItem>,
         pub contract_assignment: Box<dyn ContractAssignmentAny>,
     }
-    impl ::std::ops::Deref for DraughtingDrawingRevision {
-        type Target = DrawingRevision;
-        fn deref(&self) -> &Self::Target {
-            &self.drawing_revision
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingDrawingRevision {
         pub drawing_revision: DrawingRevision,
     }
-    impl ::std::ops::Deref for DraughtingElements {
-        type Target = DraughtingCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingElements {
         pub draughting_callout: DraughtingCallout,
-    }
-    impl ::std::ops::Deref for DraughtingGroupAssignment {
-        type Target = Box<dyn GroupAssignmentAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.group_assignment
-        }
     }
     impl GroupAssignmentAny for DraughtingGroupAssignment {}
     #[derive(Debug, derive_new :: new)]
@@ -1103,21 +785,9 @@ pub mod explicit_draughting {
         pub items: Vec<DraughtingGroupedItem>,
         pub group_assignment: Box<dyn GroupAssignmentAny>,
     }
-    impl ::std::ops::Deref for DraughtingModel {
-        type Target = Representation;
-        fn deref(&self) -> &Self::Target {
-            &self.representation
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingModel {
         pub representation: Representation,
-    }
-    impl ::std::ops::Deref for DraughtingOrganizationAssignment {
-        type Target = Box<dyn OrganizationAssignmentAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.organization_assignment
-        }
     }
     impl OrganizationAssignmentAny for DraughtingOrganizationAssignment {}
     #[derive(Debug, derive_new :: new)]
@@ -1125,23 +795,11 @@ pub mod explicit_draughting {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
         pub organization_assignment: Box<dyn OrganizationAssignmentAny>,
     }
-    impl ::std::ops::Deref for DraughtingPersonAndOrganizationAssignment {
-        type Target = Box<dyn PersonAndOrganizationAssignmentAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.person_and_organization_assignment
-        }
-    }
     impl PersonAndOrganizationAssignmentAny for DraughtingPersonAndOrganizationAssignment {}
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingPersonAndOrganizationAssignment {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
         pub person_and_organization_assignment: Box<dyn PersonAndOrganizationAssignmentAny>,
-    }
-    impl ::std::ops::Deref for DraughtingPersonAssignment {
-        type Target = Box<dyn PersonAssignmentAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.person_assignment
-        }
     }
     impl PersonAssignmentAny for DraughtingPersonAssignment {}
     #[derive(Debug, derive_new :: new)]
@@ -1149,41 +807,17 @@ pub mod explicit_draughting {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
         pub person_assignment: Box<dyn PersonAssignmentAny>,
     }
-    impl ::std::ops::Deref for DraughtingPreDefinedColour {
-        type Target = PreDefinedColour;
-        fn deref(&self) -> &Self::Target {
-            &self.pre_defined_colour
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingPreDefinedColour {
         pub pre_defined_colour: PreDefinedColour,
-    }
-    impl ::std::ops::Deref for DraughtingPreDefinedCurveFont {
-        type Target = PreDefinedCurveFont;
-        fn deref(&self) -> &Self::Target {
-            &self.pre_defined_curve_font
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingPreDefinedCurveFont {
         pub pre_defined_curve_font: PreDefinedCurveFont,
     }
-    impl ::std::ops::Deref for DraughtingPreDefinedTextFont {
-        type Target = PreDefinedTextFont;
-        fn deref(&self) -> &Self::Target {
-            &self.pre_defined_text_font
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingPreDefinedTextFont {
         pub pre_defined_text_font: PreDefinedTextFont,
-    }
-    impl ::std::ops::Deref for DraughtingPresentedItem {
-        type Target = Box<dyn PresentedItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.presented_item
-        }
     }
     impl PresentedItemAny for DraughtingPresentedItem {}
     #[derive(Debug, derive_new :: new)]
@@ -1191,23 +825,11 @@ pub mod explicit_draughting {
         pub items: Vec<DraughtingPresentedItemSelect>,
         pub presented_item: Box<dyn PresentedItemAny>,
     }
-    impl ::std::ops::Deref for DraughtingSecurityClassificationAssignment {
-        type Target = Box<dyn SecurityClassificationAssignmentAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.security_classification_assignment
-        }
-    }
     impl SecurityClassificationAssignmentAny for DraughtingSecurityClassificationAssignment {}
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingSecurityClassificationAssignment {
         pub assigned_items: Vec<ClassifiedItem>,
         pub security_classification_assignment: Box<dyn SecurityClassificationAssignmentAny>,
-    }
-    impl ::std::ops::Deref for DraughtingSpecificationReference {
-        type Target = Box<dyn DocumentReferenceAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.document_reference
-        }
     }
     impl DocumentReferenceAny for DraughtingSpecificationReference {}
     #[derive(Debug, derive_new :: new)]
@@ -1215,31 +837,13 @@ pub mod explicit_draughting {
         pub specified_items: Vec<SpecifiedItem>,
         pub document_reference: Box<dyn DocumentReferenceAny>,
     }
-    impl ::std::ops::Deref for DraughtingSubfigureRepresentation {
-        type Target = SymbolRepresentation;
-        fn deref(&self) -> &Self::Target {
-            &self.symbol_representation
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingSubfigureRepresentation {
         pub symbol_representation: SymbolRepresentation,
     }
-    impl ::std::ops::Deref for DraughtingSymbolRepresentation {
-        type Target = SymbolRepresentation;
-        fn deref(&self) -> &Self::Target {
-            &self.symbol_representation
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingSymbolRepresentation {
         pub symbol_representation: SymbolRepresentation,
-    }
-    impl ::std::ops::Deref for DraughtingTextLiteralWithDelineation {
-        type Target = TextLiteralWithDelineation;
-        fn deref(&self) -> &Self::Target {
-            &self.text_literal_with_delineation
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct DraughtingTextLiteralWithDelineation {
@@ -1256,12 +860,6 @@ pub mod explicit_draughting {
         pub drawing_number: Identifier,
         pub drawing_type: Option<Label>,
     }
-    impl ::std::ops::Deref for DrawingRevision {
-        type Target = PresentationSet;
-        fn deref(&self) -> &Self::Target {
-            &self.presentation_set
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DrawingRevision {
         pub revision_identifier: Identifier,
@@ -1269,43 +867,19 @@ pub mod explicit_draughting {
         pub intended_scale: Option<Text>,
         pub presentation_set: PresentationSet,
     }
-    impl ::std::ops::Deref for DrawingSheetLayout {
-        type Target = DraughtingSymbolRepresentation;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_symbol_representation
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DrawingSheetLayout {
         pub draughting_symbol_representation: DraughtingSymbolRepresentation,
-    }
-    impl ::std::ops::Deref for DrawingSheetRevision {
-        type Target = PresentationArea;
-        fn deref(&self) -> &Self::Target {
-            &self.presentation_area
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct DrawingSheetRevision {
         pub revision_identifier: Identifier,
         pub presentation_area: PresentationArea,
     }
-    impl ::std::ops::Deref for DrawingSheetRevisionUsage {
-        type Target = AreaInSet;
-        fn deref(&self) -> &Self::Target {
-            &self.area_in_set
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct DrawingSheetRevisionUsage {
         pub sheet_number: Identifier,
         pub area_in_set: AreaInSet,
-    }
-    impl ::std::ops::Deref for Ellipse {
-        type Target = Box<dyn ConicAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.conic
-        }
     }
     impl ConicAny for Ellipse {}
     #[derive(Debug, derive_new :: new)]
@@ -1317,12 +891,6 @@ pub mod explicit_draughting {
     #[derive(Debug, derive_new :: new)]
     pub struct ExternalSource {
         pub source_id: SourceItem,
-    }
-    impl ::std::ops::Deref for ExternallyDefinedCurveFont {
-        type Target = ExternallyDefinedItem;
-        fn deref(&self) -> &Self::Target {
-            &self.externally_defined_item
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct ExternallyDefinedCurveFont {
@@ -1339,21 +907,9 @@ pub mod explicit_draughting {
         pub item_id: SourceItem,
         pub source: ExternalSource,
     }
-    impl ::std::ops::Deref for ExternallyDefinedSymbol {
-        type Target = ExternallyDefinedItem;
-        fn deref(&self) -> &Self::Target {
-            &self.externally_defined_item
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct ExternallyDefinedSymbol {
         pub externally_defined_item: ExternallyDefinedItem,
-    }
-    impl ::std::ops::Deref for ExternallyDefinedTextFont {
-        type Target = ExternallyDefinedItem;
-        fn deref(&self) -> &Self::Target {
-            &self.externally_defined_item
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct ExternallyDefinedTextFont {
@@ -1375,12 +931,6 @@ pub mod explicit_draughting {
         pub name: Label,
         pub fill_colour: Colour,
     }
-    impl ::std::ops::Deref for FillAreaStyleHatching {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
-    }
     impl GeometricRepresentationItemAny for FillAreaStyleHatching {}
     #[derive(Debug, derive_new :: new)]
     pub struct FillAreaStyleHatching {
@@ -1391,23 +941,11 @@ pub mod explicit_draughting {
         pub hatch_line_angle: PlaneAngleMeasure,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    impl ::std::ops::Deref for FillAreaStyleTileSymbolWithStyle {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
-    }
     impl GeometricRepresentationItemAny for FillAreaStyleTileSymbolWithStyle {}
     #[derive(Debug, derive_new :: new)]
     pub struct FillAreaStyleTileSymbolWithStyle {
         pub symbol: AnnotationSymbolOccurrence,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
-    }
-    impl ::std::ops::Deref for FillAreaStyleTiles {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for FillAreaStyleTiles {}
     #[derive(Debug, derive_new :: new)]
@@ -1417,33 +955,15 @@ pub mod explicit_draughting {
         pub tiling_scale: PositiveRatioMeasure,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    impl ::std::ops::Deref for GeometricCurveSet {
-        type Target = Box<dyn GeometricSetAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_set
-        }
-    }
     impl GeometricSetAny for GeometricCurveSet {}
     #[derive(Debug, derive_new :: new)]
     pub struct GeometricCurveSet {
         pub geometric_set: Box<dyn GeometricSetAny>,
     }
-    impl ::std::ops::Deref for GeometricRepresentationContext {
-        type Target = RepresentationContext;
-        fn deref(&self) -> &Self::Target {
-            &self.representation_context
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct GeometricRepresentationContext {
         pub coordinate_space_dimension: DimensionCount,
         pub representation_context: RepresentationContext,
-    }
-    impl ::std::ops::Deref for GeometricRepresentationItem {
-        type Target = RepresentationItem;
-        fn deref(&self) -> &Self::Target {
-            &self.representation_item
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct GeometricRepresentationItem {
@@ -1451,12 +971,6 @@ pub mod explicit_draughting {
     }
     pub trait GeometricRepresentationItemAny: ::std::any::Any + ::std::fmt::Debug {}
     impl GeometricRepresentationItemAny for GeometricRepresentationItem {}
-    impl ::std::ops::Deref for GeometricSet {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
-    }
     impl GeometricRepresentationItemAny for GeometricSet {}
     #[derive(Debug, derive_new :: new)]
     pub struct GeometricSet {
@@ -1465,31 +979,13 @@ pub mod explicit_draughting {
     }
     pub trait GeometricSetAny: ::std::any::Any + ::std::fmt::Debug {}
     impl GeometricSetAny for GeometricSet {}
-    impl ::std::ops::Deref for GeometricalToleranceCallout {
-        type Target = DraughtingCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct GeometricalToleranceCallout {
         pub draughting_callout: DraughtingCallout,
     }
-    impl ::std::ops::Deref for GeometricallyBounded2DWireframeRepresentation {
-        type Target = ShapeRepresentation;
-        fn deref(&self) -> &Self::Target {
-            &self.shape_representation
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct GeometricallyBounded2DWireframeRepresentation {
         pub shape_representation: ShapeRepresentation,
-    }
-    impl ::std::ops::Deref for GlobalUnitAssignedContext {
-        type Target = RepresentationContext;
-        fn deref(&self) -> &Self::Target {
-            &self.representation_context
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct GlobalUnitAssignedContext {
@@ -1514,12 +1010,6 @@ pub mod explicit_draughting {
         pub relating_group: Group,
         pub related_group: Group,
     }
-    impl ::std::ops::Deref for Hyperbola {
-        type Target = Box<dyn ConicAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.conic
-        }
-    }
     impl ConicAny for Hyperbola {}
     #[derive(Debug, derive_new :: new)]
     pub struct Hyperbola {
@@ -1531,73 +1021,31 @@ pub mod explicit_draughting {
     pub struct Invisibility {
         pub invisible_items: Vec<InvisibleItem>,
     }
-    impl ::std::ops::Deref for LeaderCurve {
-        type Target = AnnotationCurveOccurrence;
-        fn deref(&self) -> &Self::Target {
-            &self.annotation_curve_occurrence
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct LeaderCurve {
         pub annotation_curve_occurrence: AnnotationCurveOccurrence,
-    }
-    impl ::std::ops::Deref for LeaderDirectedCallout {
-        type Target = DraughtingCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_callout
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct LeaderDirectedCallout {
         pub draughting_callout: DraughtingCallout,
     }
-    impl ::std::ops::Deref for LeaderDirectedDimension {
-        type Target = LeaderDirectedCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.leader_directed_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct LeaderDirectedDimension {
         pub leader_directed_callout: LeaderDirectedCallout,
     }
-    impl ::std::ops::Deref for LeaderTerminator {
-        type Target = TerminatorSymbol;
-        fn deref(&self) -> &Self::Target {
-            &self.terminator_symbol
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct LeaderTerminator {
         pub terminator_symbol: TerminatorSymbol,
-    }
-    impl ::std::ops::Deref for LengthMeasureWithUnit {
-        type Target = Box<dyn MeasureWithUnitAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.measure_with_unit
-        }
     }
     impl MeasureWithUnitAny for LengthMeasureWithUnit {}
     #[derive(Debug, derive_new :: new)]
     pub struct LengthMeasureWithUnit {
         pub measure_with_unit: Box<dyn MeasureWithUnitAny>,
     }
-    impl ::std::ops::Deref for LengthUnit {
-        type Target = Box<dyn NamedUnitAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.named_unit
-        }
-    }
     impl NamedUnitAny for LengthUnit {}
     #[derive(Debug, derive_new :: new)]
     pub struct LengthUnit {
         pub named_unit: Box<dyn NamedUnitAny>,
-    }
-    impl ::std::ops::Deref for Line {
-        type Target = Box<dyn CurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.curve
-        }
     }
     impl CurveAny for Line {}
     #[derive(Debug, derive_new :: new)]
@@ -1606,21 +1054,9 @@ pub mod explicit_draughting {
         pub dir: Vector,
         pub curve: Box<dyn CurveAny>,
     }
-    impl ::std::ops::Deref for LinearDimension {
-        type Target = DimensionCurveDirectedCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.dimension_curve_directed_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct LinearDimension {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
-    }
-    impl ::std::ops::Deref for MappedItem {
-        type Target = RepresentationItem;
-        fn deref(&self) -> &Self::Target {
-            &self.representation_item
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct MappedItem {
@@ -1641,12 +1077,6 @@ pub mod explicit_draughting {
     }
     pub trait NamedUnitAny: ::std::any::Any + ::std::fmt::Debug {}
     impl NamedUnitAny for NamedUnit {}
-    impl ::std::ops::Deref for OffsetCurve2D {
-        type Target = Box<dyn CurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.curve
-        }
-    }
     impl CurveAny for OffsetCurve2D {}
     #[derive(Debug, derive_new :: new)]
     pub struct OffsetCurve2D {
@@ -1655,23 +1085,11 @@ pub mod explicit_draughting {
         pub self_intersect: Logical,
         pub curve: Box<dyn CurveAny>,
     }
-    impl ::std::ops::Deref for OneDirectionRepeatFactor {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
-    }
     impl GeometricRepresentationItemAny for OneDirectionRepeatFactor {}
     #[derive(Debug, derive_new :: new)]
     pub struct OneDirectionRepeatFactor {
         pub repeat_factor: Vector,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
-    }
-    impl ::std::ops::Deref for OrdinateDimension {
-        type Target = ProjectionDirectedCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.projection_directed_callout
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct OrdinateDimension {
@@ -1694,23 +1112,11 @@ pub mod explicit_draughting {
     pub struct OrganizationRole {
         pub name: Label,
     }
-    impl ::std::ops::Deref for OrganizationalAddress {
-        type Target = Address;
-        fn deref(&self) -> &Self::Target {
-            &self.address
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct OrganizationalAddress {
         pub organizations: Vec<Organization>,
         pub description: Text,
         pub address: Address,
-    }
-    impl ::std::ops::Deref for Parabola {
-        type Target = Box<dyn ConicAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.conic
-        }
     }
     impl ConicAny for Parabola {}
     #[derive(Debug, derive_new :: new)]
@@ -1754,23 +1160,11 @@ pub mod explicit_draughting {
     pub struct PersonRole {
         pub name: Label,
     }
-    impl ::std::ops::Deref for PersonalAddress {
-        type Target = Address;
-        fn deref(&self) -> &Self::Target {
-            &self.address
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct PersonalAddress {
         pub people: Vec<Person>,
         pub description: Text,
         pub address: Address,
-    }
-    impl ::std::ops::Deref for Placement {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for Placement {}
     #[derive(Debug, derive_new :: new)]
@@ -1780,22 +1174,10 @@ pub mod explicit_draughting {
     }
     pub trait PlacementAny: ::std::any::Any + ::std::fmt::Debug {}
     impl PlacementAny for Placement {}
-    impl ::std::ops::Deref for PlanarBox {
-        type Target = PlanarExtent;
-        fn deref(&self) -> &Self::Target {
-            &self.planar_extent
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct PlanarBox {
         pub placement: Axis2Placement,
         pub planar_extent: PlanarExtent,
-    }
-    impl ::std::ops::Deref for PlanarExtent {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for PlanarExtent {}
     #[derive(Debug, derive_new :: new)]
@@ -1804,33 +1186,15 @@ pub mod explicit_draughting {
         pub size_in_y: LengthMeasure,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    impl ::std::ops::Deref for PlaneAngleMeasureWithUnit {
-        type Target = Box<dyn MeasureWithUnitAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.measure_with_unit
-        }
-    }
     impl MeasureWithUnitAny for PlaneAngleMeasureWithUnit {}
     #[derive(Debug, derive_new :: new)]
     pub struct PlaneAngleMeasureWithUnit {
         pub measure_with_unit: Box<dyn MeasureWithUnitAny>,
     }
-    impl ::std::ops::Deref for PlaneAngleUnit {
-        type Target = Box<dyn NamedUnitAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.named_unit
-        }
-    }
     impl NamedUnitAny for PlaneAngleUnit {}
     #[derive(Debug, derive_new :: new)]
     pub struct PlaneAngleUnit {
         pub named_unit: Box<dyn NamedUnitAny>,
-    }
-    impl ::std::ops::Deref for Point {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for Point {}
     #[derive(Debug, derive_new :: new)]
@@ -1839,24 +1203,12 @@ pub mod explicit_draughting {
     }
     pub trait PointAny: ::std::any::Any + ::std::fmt::Debug {}
     impl PointAny for Point {}
-    impl ::std::ops::Deref for PointOnCurve {
-        type Target = Box<dyn PointAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.point
-        }
-    }
     impl PointAny for PointOnCurve {}
     #[derive(Debug, derive_new :: new)]
     pub struct PointOnCurve {
         pub basis_curve: Box<dyn CurveAny>,
         pub point_parameter: ParameterValue,
         pub point: Box<dyn PointAny>,
-    }
-    impl ::std::ops::Deref for Polyline {
-        type Target = Box<dyn BoundedCurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.bounded_curve
-        }
     }
     impl BoundedCurveAny for Polyline {}
     #[derive(Debug, derive_new :: new)]
@@ -1869,31 +1221,13 @@ pub mod explicit_draughting {
         pub pre_defined_item: PreDefinedItem,
         pub colour: Colour,
     }
-    impl ::std::ops::Deref for PreDefinedCurveFont {
-        type Target = PreDefinedItem;
-        fn deref(&self) -> &Self::Target {
-            &self.pre_defined_item
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedCurveFont {
         pub pre_defined_item: PreDefinedItem,
     }
-    impl ::std::ops::Deref for PreDefinedDimensionSymbol {
-        type Target = PreDefinedSymbol;
-        fn deref(&self) -> &Self::Target {
-            &self.pre_defined_symbol
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedDimensionSymbol {
         pub pre_defined_symbol: PreDefinedSymbol,
-    }
-    impl ::std::ops::Deref for PreDefinedGeometricalToleranceSymbol {
-        type Target = PreDefinedSymbol;
-        fn deref(&self) -> &Self::Target {
-            &self.pre_defined_symbol
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedGeometricalToleranceSymbol {
@@ -1903,51 +1237,21 @@ pub mod explicit_draughting {
     pub struct PreDefinedItem {
         pub name: Label,
     }
-    impl ::std::ops::Deref for PreDefinedPointMarkerSymbol {
-        type Target = PreDefinedSymbol;
-        fn deref(&self) -> &Self::Target {
-            &self.pre_defined_symbol
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedPointMarkerSymbol {
         pub pre_defined_symbol: PreDefinedSymbol,
-    }
-    impl ::std::ops::Deref for PreDefinedSymbol {
-        type Target = PreDefinedItem;
-        fn deref(&self) -> &Self::Target {
-            &self.pre_defined_item
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedSymbol {
         pub pre_defined_item: PreDefinedItem,
     }
-    impl ::std::ops::Deref for PreDefinedTerminatorSymbol {
-        type Target = PreDefinedSymbol;
-        fn deref(&self) -> &Self::Target {
-            &self.pre_defined_symbol
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedTerminatorSymbol {
         pub pre_defined_symbol: PreDefinedSymbol,
     }
-    impl ::std::ops::Deref for PreDefinedTextFont {
-        type Target = PreDefinedItem;
-        fn deref(&self) -> &Self::Target {
-            &self.pre_defined_item
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct PreDefinedTextFont {
         pub pre_defined_item: PreDefinedItem,
-    }
-    impl ::std::ops::Deref for PresentationArea {
-        type Target = PresentationRepresentation;
-        fn deref(&self) -> &Self::Target {
-            &self.presentation_representation
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct PresentationArea {
@@ -1964,12 +1268,6 @@ pub mod explicit_draughting {
         pub assignment: PresentationLayerAssignment,
         pub presentation: PresentationRepresentation,
     }
-    impl ::std::ops::Deref for PresentationRepresentation {
-        type Target = Representation;
-        fn deref(&self) -> &Self::Target {
-            &self.representation
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct PresentationRepresentation {
         pub representation: Representation,
@@ -1985,22 +1283,10 @@ pub mod explicit_draughting {
     pub struct PresentationStyleAssignment {
         pub styles: Vec<PresentationStyleSelect>,
     }
-    impl ::std::ops::Deref for PresentationStyleByContext {
-        type Target = PresentationStyleAssignment;
-        fn deref(&self) -> &Self::Target {
-            &self.presentation_style_assignment
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct PresentationStyleByContext {
         pub style_context: StyleContextSelect,
         pub presentation_style_assignment: PresentationStyleAssignment,
-    }
-    impl ::std::ops::Deref for PresentationView {
-        type Target = PresentationRepresentation;
-        fn deref(&self) -> &Self::Target {
-            &self.presentation_representation
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct PresentationView {
@@ -2022,12 +1308,6 @@ pub mod explicit_draughting {
         pub description: Text,
         pub frame_of_reference: Vec<ProductContext>,
     }
-    impl ::std::ops::Deref for ProductContext {
-        type Target = Box<dyn ApplicationContextElementAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.application_context_element
-        }
-    }
     impl ApplicationContextElementAny for ProductContext {}
     #[derive(Debug, derive_new :: new)]
     pub struct ProductContext {
@@ -2041,12 +1321,6 @@ pub mod explicit_draughting {
         pub formation: ProductDefinitionFormation,
         pub frame_of_reference: ProductDefinitionContext,
     }
-    impl ::std::ops::Deref for ProductDefinitionContext {
-        type Target = Box<dyn ApplicationContextElementAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.application_context_element
-        }
-    }
     impl ApplicationContextElementAny for ProductDefinitionContext {}
     #[derive(Debug, derive_new :: new)]
     pub struct ProductDefinitionContext {
@@ -2059,31 +1333,13 @@ pub mod explicit_draughting {
         pub description: Text,
         pub of_product: Product,
     }
-    impl ::std::ops::Deref for ProductDefinitionShape {
-        type Target = PropertyDefinition;
-        fn deref(&self) -> &Self::Target {
-            &self.property_definition
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct ProductDefinitionShape {
         pub property_definition: PropertyDefinition,
     }
-    impl ::std::ops::Deref for ProjectionCurve {
-        type Target = AnnotationCurveOccurrence;
-        fn deref(&self) -> &Self::Target {
-            &self.annotation_curve_occurrence
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct ProjectionCurve {
         pub annotation_curve_occurrence: AnnotationCurveOccurrence,
-    }
-    impl ::std::ops::Deref for ProjectionDirectedCallout {
-        type Target = DraughtingCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_callout
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct ProjectionDirectedCallout {
@@ -2100,32 +1356,14 @@ pub mod explicit_draughting {
         pub definition: PropertyDefinition,
         pub used_representation: Representation,
     }
-    impl ::std::ops::Deref for QuasiUniformCurve {
-        type Target = Box<dyn BSplineCurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.b_spline_curve
-        }
-    }
     impl BSplineCurveAny for QuasiUniformCurve {}
     #[derive(Debug, derive_new :: new)]
     pub struct QuasiUniformCurve {
         pub b_spline_curve: Box<dyn BSplineCurveAny>,
     }
-    impl ::std::ops::Deref for RadiusDimension {
-        type Target = DimensionCurveDirectedCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.dimension_curve_directed_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct RadiusDimension {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
-    }
-    impl ::std::ops::Deref for RationalBSplineCurve {
-        type Target = Box<dyn BSplineCurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.b_spline_curve
-        }
     }
     impl BSplineCurveAny for RationalBSplineCurve {}
     #[derive(Debug, derive_new :: new)]
@@ -2169,31 +1407,13 @@ pub mod explicit_draughting {
     pub struct SecurityClassificationLevel {
         pub name: Label,
     }
-    impl ::std::ops::Deref for ShapeDefinitionRepresentation {
-        type Target = PropertyDefinitionRepresentation;
-        fn deref(&self) -> &Self::Target {
-            &self.property_definition_representation
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct ShapeDefinitionRepresentation {
         pub property_definition_representation: PropertyDefinitionRepresentation,
     }
-    impl ::std::ops::Deref for ShapeRepresentation {
-        type Target = Representation;
-        fn deref(&self) -> &Self::Target {
-            &self.representation
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct ShapeRepresentation {
         pub representation: Representation,
-    }
-    impl ::std::ops::Deref for SiUnit {
-        type Target = Box<dyn NamedUnitAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.named_unit
-        }
     }
     impl NamedUnitAny for SiUnit {}
     #[derive(Debug, derive_new :: new)]
@@ -2202,21 +1422,9 @@ pub mod explicit_draughting {
         pub name: SiUnitName,
         pub named_unit: Box<dyn NamedUnitAny>,
     }
-    impl ::std::ops::Deref for StructuredDimensionCallout {
-        type Target = DraughtingCallout;
-        fn deref(&self) -> &Self::Target {
-            &self.draughting_callout
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct StructuredDimensionCallout {
         pub draughting_callout: DraughtingCallout,
-    }
-    impl ::std::ops::Deref for StyledItem {
-        type Target = RepresentationItem;
-        fn deref(&self) -> &Self::Target {
-            &self.representation_item
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct StyledItem {
@@ -2228,21 +1436,9 @@ pub mod explicit_draughting {
     pub struct SymbolColour {
         pub colour_of_symbol: Colour,
     }
-    impl ::std::ops::Deref for SymbolRepresentation {
-        type Target = Representation;
-        fn deref(&self) -> &Self::Target {
-            &self.representation
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct SymbolRepresentation {
         pub representation: Representation,
-    }
-    impl ::std::ops::Deref for SymbolRepresentationMap {
-        type Target = RepresentationMap;
-        fn deref(&self) -> &Self::Target {
-            &self.representation_map
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct SymbolRepresentationMap {
@@ -2253,12 +1449,6 @@ pub mod explicit_draughting {
         pub name: Label,
         pub style_of_symbol: SymbolStyleSelect,
     }
-    impl ::std::ops::Deref for SymbolTarget {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
-    }
     impl GeometricRepresentationItemAny for SymbolTarget {}
     #[derive(Debug, derive_new :: new)]
     pub struct SymbolTarget {
@@ -2267,22 +1457,10 @@ pub mod explicit_draughting {
         pub y_scale: PositiveRatioMeasure,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    impl ::std::ops::Deref for TerminatorSymbol {
-        type Target = AnnotationSymbolOccurrence;
-        fn deref(&self) -> &Self::Target {
-            &self.annotation_symbol_occurrence
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct TerminatorSymbol {
         pub annotated_curve: AnnotationCurveOccurrence,
         pub annotation_symbol_occurrence: AnnotationSymbolOccurrence,
-    }
-    impl ::std::ops::Deref for TextLiteral {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for TextLiteral {}
     #[derive(Debug, derive_new :: new)]
@@ -2294,44 +1472,20 @@ pub mod explicit_draughting {
         pub font: FontSelect,
         pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
-    impl ::std::ops::Deref for TextLiteralWithAssociatedCurves {
-        type Target = TextLiteral;
-        fn deref(&self) -> &Self::Target {
-            &self.text_literal
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct TextLiteralWithAssociatedCurves {
         pub associated_curves: Vec<Box<dyn CurveAny>>,
         pub text_literal: TextLiteral,
-    }
-    impl ::std::ops::Deref for TextLiteralWithBlankingBox {
-        type Target = TextLiteral;
-        fn deref(&self) -> &Self::Target {
-            &self.text_literal
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct TextLiteralWithBlankingBox {
         pub blanking: PlanarBox,
         pub text_literal: TextLiteral,
     }
-    impl ::std::ops::Deref for TextLiteralWithDelineation {
-        type Target = TextLiteral;
-        fn deref(&self) -> &Self::Target {
-            &self.text_literal
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct TextLiteralWithDelineation {
         pub delineation: TextDelineation,
         pub text_literal: TextLiteral,
-    }
-    impl ::std::ops::Deref for TextLiteralWithExtent {
-        type Target = TextLiteral;
-        fn deref(&self) -> &Self::Target {
-            &self.text_literal
-        }
     }
     #[derive(Debug, derive_new :: new)]
     pub struct TextLiteralWithExtent {
@@ -2347,33 +1501,15 @@ pub mod explicit_draughting {
     pub struct TextStyleForDefinedFont {
         pub text_colour: Colour,
     }
-    impl ::std::ops::Deref for TextStyleWithBoxCharacteristics {
-        type Target = TextStyle;
-        fn deref(&self) -> &Self::Target {
-            &self.text_style
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct TextStyleWithBoxCharacteristics {
         pub characteristics: Vec<BoxCharacteristicSelect>,
         pub text_style: TextStyle,
     }
-    impl ::std::ops::Deref for TextStyleWithMirror {
-        type Target = TextStyle;
-        fn deref(&self) -> &Self::Target {
-            &self.text_style
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct TextStyleWithMirror {
         pub mirror_placement: Axis2Placement,
         pub text_style: TextStyle,
-    }
-    impl ::std::ops::Deref for TrimmedCurve {
-        type Target = Box<dyn BoundedCurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.bounded_curve
-        }
     }
     impl BoundedCurveAny for TrimmedCurve {}
     #[derive(Debug, derive_new :: new)]
@@ -2385,33 +1521,15 @@ pub mod explicit_draughting {
         pub master_representation: TrimmingPreference,
         pub bounded_curve: Box<dyn BoundedCurveAny>,
     }
-    impl ::std::ops::Deref for TwoDirectionRepeatFactor {
-        type Target = OneDirectionRepeatFactor;
-        fn deref(&self) -> &Self::Target {
-            &self.one_direction_repeat_factor
-        }
-    }
     #[derive(Debug, derive_new :: new)]
     pub struct TwoDirectionRepeatFactor {
         pub second_repeat_factor: Vector,
         pub one_direction_repeat_factor: OneDirectionRepeatFactor,
     }
-    impl ::std::ops::Deref for UniformCurve {
-        type Target = Box<dyn BSplineCurveAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.b_spline_curve
-        }
-    }
     impl BSplineCurveAny for UniformCurve {}
     #[derive(Debug, derive_new :: new)]
     pub struct UniformCurve {
         pub b_spline_curve: Box<dyn BSplineCurveAny>,
-    }
-    impl ::std::ops::Deref for Vector {
-        type Target = Box<dyn GeometricRepresentationItemAny>;
-        fn deref(&self) -> &Self::Target {
-            &self.geometric_representation_item
-        }
     }
     impl GeometricRepresentationItemAny for Vector {}
     #[derive(Debug, derive_new :: new)]

--- a/ruststep/src/ap201.rs
+++ b/ruststep/src/ap201.rs
@@ -39,7 +39,7 @@ pub mod explicit_draughting {
     pub enum CharacterSpacingSelect {
         LengthMeasure(Box<LengthMeasure>),
         RatioMeasure(Box<RatioMeasure>),
-        MeasureWithUnit(Box<MeasureWithUnit>),
+        MeasureWithUnit(Box<dyn MeasureWithUnitAny>),
     }
     #[derive(Debug, Clone, PartialEq)]
     pub enum CharacterStyleSelect {
@@ -69,7 +69,7 @@ pub mod explicit_draughting {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub enum CurveOrAnnotationCurveOccurrence {
-        Curve(Box<Curve>),
+        Curve(Box<dyn CurveAny>),
         AnnotationCurveOccurrence(Box<AnnotationCurveOccurrence>),
     }
     #[derive(Debug, Clone, PartialEq)]
@@ -84,7 +84,7 @@ pub mod explicit_draughting {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub enum DateTimeSelect {
-        Date(Box<Date>),
+        Date(Box<dyn DateAny>),
     }
     pub type DayInMonthNumber = i64;
     #[derive(Debug, Clone, PartialEq)]
@@ -106,7 +106,7 @@ pub mod explicit_draughting {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub enum DraughtingGroupedItem {
-        AnnotationOccurrence(Box<AnnotationOccurrence>),
+        AnnotationOccurrence(Box<dyn AnnotationOccurrenceAny>),
         GeometricSetSelect(Box<GeometricSetSelect>),
     }
     #[derive(Debug, Clone, PartialEq)]
@@ -143,8 +143,8 @@ pub mod explicit_draughting {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub enum GeometricSetSelect {
-        Point(Box<Point>),
-        Curve(Box<Curve>),
+        Point(Box<dyn PointAny>),
+        Curve(Box<dyn CurveAny>),
     }
     #[derive(Debug, Clone, PartialEq)]
     pub enum HidingOrBlankingSelect {
@@ -281,7 +281,7 @@ pub mod explicit_draughting {
     #[derive(Debug, Clone, PartialEq)]
     pub enum SizeSelect {
         PositiveLengthMeasure(Box<PositiveLengthMeasure>),
-        MeasureWithUnit(Box<MeasureWithUnit>),
+        MeasureWithUnit(Box<dyn MeasureWithUnitAny>),
     }
     #[derive(Debug, Clone, PartialEq)]
     pub enum SourceItem {
@@ -337,7 +337,7 @@ pub mod explicit_draughting {
     }
     #[derive(Debug, Clone, PartialEq)]
     pub enum Unit {
-        NamedUnit(Box<NamedUnit>),
+        NamedUnit(Box<dyn NamedUnitAny>),
     }
     #[derive(Debug, Clone, PartialEq)]
     pub enum VectorOrDirection {
@@ -371,7 +371,7 @@ pub mod explicit_draughting {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
     }
     impl ::std::ops::Deref for AnnotationCurveOccurrence {
-        type Target = AnnotationOccurrence;
+        type Target = Box<dyn AnnotationOccurrenceAny>;
         fn deref(&self) -> &Self::Target {
             &self.annotation_occurrence
         }
@@ -379,10 +379,10 @@ pub mod explicit_draughting {
     impl AnnotationOccurrenceAny for AnnotationCurveOccurrence {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct AnnotationCurveOccurrence {
-        pub annotation_occurrence: AnnotationOccurrence,
+        pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
     }
     impl ::std::ops::Deref for AnnotationFillArea {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -390,11 +390,11 @@ pub mod explicit_draughting {
     impl GeometricRepresentationItemAny for AnnotationFillArea {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct AnnotationFillArea {
-        pub boundaries: Vec<Curve>,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub boundaries: Vec<Box<dyn CurveAny>>,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     impl ::std::ops::Deref for AnnotationFillAreaOccurrence {
-        type Target = AnnotationOccurrence;
+        type Target = Box<dyn AnnotationOccurrenceAny>;
         fn deref(&self) -> &Self::Target {
             &self.annotation_occurrence
         }
@@ -402,8 +402,8 @@ pub mod explicit_draughting {
     impl AnnotationOccurrenceAny for AnnotationFillAreaOccurrence {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct AnnotationFillAreaOccurrence {
-        pub fill_style_target: Point,
-        pub annotation_occurrence: AnnotationOccurrence,
+        pub fill_style_target: Box<dyn PointAny>,
+        pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
     }
     impl ::std::ops::Deref for AnnotationOccurrence {
         type Target = StyledItem;
@@ -438,7 +438,7 @@ pub mod explicit_draughting {
         pub mapped_item: MappedItem,
     }
     impl ::std::ops::Deref for AnnotationSymbolOccurrence {
-        type Target = AnnotationOccurrence;
+        type Target = Box<dyn AnnotationOccurrenceAny>;
         fn deref(&self) -> &Self::Target {
             &self.annotation_occurrence
         }
@@ -446,7 +446,7 @@ pub mod explicit_draughting {
     impl AnnotationOccurrenceAny for AnnotationSymbolOccurrence {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct AnnotationSymbolOccurrence {
-        pub annotation_occurrence: AnnotationOccurrence,
+        pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
     }
     impl ::std::ops::Deref for AnnotationText {
         type Target = MappedItem;
@@ -459,7 +459,7 @@ pub mod explicit_draughting {
         pub mapped_item: MappedItem,
     }
     impl ::std::ops::Deref for AnnotationTextOccurrence {
-        type Target = AnnotationOccurrence;
+        type Target = Box<dyn AnnotationOccurrenceAny>;
         fn deref(&self) -> &Self::Target {
             &self.annotation_occurrence
         }
@@ -467,7 +467,7 @@ pub mod explicit_draughting {
     impl AnnotationOccurrenceAny for AnnotationTextOccurrence {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct AnnotationTextOccurrence {
-        pub annotation_occurrence: AnnotationOccurrence,
+        pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ApplicationContext {
@@ -523,7 +523,7 @@ pub mod explicit_draughting {
         pub in_set: PresentationSet,
     }
     impl ::std::ops::Deref for Axis2Placement2D {
-        type Target = Placement;
+        type Target = Box<dyn PlacementAny>;
         fn deref(&self) -> &Self::Target {
             &self.placement
         }
@@ -532,10 +532,10 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Axis2Placement2D {
         pub ref_direction: Option<Direction>,
-        pub placement: Placement,
+        pub placement: Box<dyn PlacementAny>,
     }
     impl ::std::ops::Deref for BSplineCurve {
-        type Target = BoundedCurve;
+        type Target = Box<dyn BoundedCurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.bounded_curve
         }
@@ -548,12 +548,12 @@ pub mod explicit_draughting {
         pub curve_form: BSplineCurveForm,
         pub closed_curve: Logical,
         pub self_intersect: Logical,
-        pub bounded_curve: BoundedCurve,
+        pub bounded_curve: Box<dyn BoundedCurveAny>,
     }
     pub trait BSplineCurveAny: ::std::any::Any + ::std::fmt::Debug {}
     impl BSplineCurveAny for BSplineCurve {}
     impl ::std::ops::Deref for BSplineCurveWithKnots {
-        type Target = BSplineCurve;
+        type Target = Box<dyn BSplineCurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.b_spline_curve
         }
@@ -564,10 +564,10 @@ pub mod explicit_draughting {
         pub knot_multiplicities: Vec<i64>,
         pub knots: Vec<ParameterValue>,
         pub knot_spec: KnotType,
-        pub b_spline_curve: BSplineCurve,
+        pub b_spline_curve: Box<dyn BSplineCurveAny>,
     }
     impl ::std::ops::Deref for BezierCurve {
-        type Target = BSplineCurve;
+        type Target = Box<dyn BSplineCurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.b_spline_curve
         }
@@ -575,10 +575,10 @@ pub mod explicit_draughting {
     impl BSplineCurveAny for BezierCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct BezierCurve {
-        pub b_spline_curve: BSplineCurve,
+        pub b_spline_curve: Box<dyn BSplineCurveAny>,
     }
     impl ::std::ops::Deref for BoundedCurve {
-        type Target = Curve;
+        type Target = Box<dyn CurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.curve
         }
@@ -586,12 +586,12 @@ pub mod explicit_draughting {
     impl CurveAny for BoundedCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct BoundedCurve {
-        pub curve: Curve,
+        pub curve: Box<dyn CurveAny>,
     }
     pub trait BoundedCurveAny: ::std::any::Any + ::std::fmt::Debug {}
     impl BoundedCurveAny for BoundedCurve {}
     impl ::std::ops::Deref for CalendarDate {
-        type Target = Date;
+        type Target = Box<dyn DateAny>;
         fn deref(&self) -> &Self::Target {
             &self.date
         }
@@ -601,7 +601,7 @@ pub mod explicit_draughting {
     pub struct CalendarDate {
         pub day_component: DayInMonthNumber,
         pub month_component: MonthInYearNumber,
-        pub date: Date,
+        pub date: Box<dyn DateAny>,
     }
     impl ::std::ops::Deref for CameraImage {
         type Target = MappedItem;
@@ -624,7 +624,7 @@ pub mod explicit_draughting {
         pub camera_image: CameraImage,
     }
     impl ::std::ops::Deref for CameraModel {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -632,12 +632,12 @@ pub mod explicit_draughting {
     impl GeometricRepresentationItemAny for CameraModel {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct CameraModel {
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     pub trait CameraModelAny: ::std::any::Any + ::std::fmt::Debug {}
     impl CameraModelAny for CameraModel {}
     impl ::std::ops::Deref for CameraModelD2 {
-        type Target = CameraModel;
+        type Target = Box<dyn CameraModelAny>;
         fn deref(&self) -> &Self::Target {
             &self.camera_model
         }
@@ -647,7 +647,7 @@ pub mod explicit_draughting {
     pub struct CameraModelD2 {
         pub view_window: PlanarBox,
         pub view_window_clipping: bool,
-        pub camera_model: CameraModel,
+        pub camera_model: Box<dyn CameraModelAny>,
     }
     impl ::std::ops::Deref for CameraUsage {
         type Target = RepresentationMap;
@@ -660,7 +660,7 @@ pub mod explicit_draughting {
         pub representation_map: RepresentationMap,
     }
     impl ::std::ops::Deref for CartesianPoint {
-        type Target = Point;
+        type Target = Box<dyn PointAny>;
         fn deref(&self) -> &Self::Target {
             &self.point
         }
@@ -669,10 +669,10 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct CartesianPoint {
         pub coordinates: Vec<LengthMeasure>,
-        pub point: Point,
+        pub point: Box<dyn PointAny>,
     }
     impl ::std::ops::Deref for Circle {
-        type Target = Conic;
+        type Target = Box<dyn ConicAny>;
         fn deref(&self) -> &Self::Target {
             &self.conic
         }
@@ -681,7 +681,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Circle {
         pub radius: PositiveLengthMeasure,
-        pub conic: Conic,
+        pub conic: Box<dyn ConicAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Colour {}
@@ -710,7 +710,7 @@ pub mod explicit_draughting {
         pub colour: Colour,
     }
     impl ::std::ops::Deref for CompositeCurve {
-        type Target = BoundedCurve;
+        type Target = Box<dyn BoundedCurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.bounded_curve
         }
@@ -720,16 +720,16 @@ pub mod explicit_draughting {
     pub struct CompositeCurve {
         pub segments: Vec<CompositeCurveSegment>,
         pub self_intersect: Logical,
-        pub bounded_curve: BoundedCurve,
+        pub bounded_curve: Box<dyn BoundedCurveAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct CompositeCurveSegment {
         pub transition: TransitionCode,
         pub same_sense: bool,
-        pub parent_curve: Curve,
+        pub parent_curve: Box<dyn CurveAny>,
     }
     impl ::std::ops::Deref for CompositeText {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -738,7 +738,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct CompositeText {
         pub collected_text: Vec<TextOrCharacter>,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     impl ::std::ops::Deref for CompositeTextWithAssociatedCurves {
         type Target = CompositeText;
@@ -748,7 +748,7 @@ pub mod explicit_draughting {
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct CompositeTextWithAssociatedCurves {
-        pub associated_curves: Vec<Curve>,
+        pub associated_curves: Vec<Box<dyn CurveAny>>,
         pub composite_text: CompositeText,
     }
     impl ::std::ops::Deref for CompositeTextWithBlankingBox {
@@ -774,7 +774,7 @@ pub mod explicit_draughting {
         pub composite_text: CompositeText,
     }
     impl ::std::ops::Deref for Conic {
-        type Target = Curve;
+        type Target = Box<dyn CurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.curve
         }
@@ -783,7 +783,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Conic {
         pub position: Axis2Placement,
-        pub curve: Curve,
+        pub curve: Box<dyn CurveAny>,
     }
     pub trait ConicAny: ::std::any::Any + ::std::fmt::Debug {}
     impl ConicAny for Conic {}
@@ -815,7 +815,7 @@ pub mod explicit_draughting {
         pub description: Label,
     }
     impl ::std::ops::Deref for ConversionBasedUnit {
-        type Target = NamedUnit;
+        type Target = Box<dyn NamedUnitAny>;
         fn deref(&self) -> &Self::Target {
             &self.named_unit
         }
@@ -824,11 +824,11 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ConversionBasedUnit {
         pub name: Label,
-        pub conversion_factor: MeasureWithUnit,
-        pub named_unit: NamedUnit,
+        pub conversion_factor: Box<dyn MeasureWithUnitAny>,
+        pub named_unit: Box<dyn NamedUnitAny>,
     }
     impl ::std::ops::Deref for Curve {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -836,7 +836,7 @@ pub mod explicit_draughting {
     impl GeometricRepresentationItemAny for Curve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Curve {
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     pub trait CurveAny: ::std::any::Any + ::std::fmt::Debug {}
     impl CurveAny for Curve {}
@@ -894,7 +894,7 @@ pub mod explicit_draughting {
         pub draughting_callout: DraughtingCallout,
     }
     impl ::std::ops::Deref for DefinedSymbol {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -904,7 +904,7 @@ pub mod explicit_draughting {
     pub struct DefinedSymbol {
         pub definition: DefinedSymbolSelect,
         pub target: SymbolTarget,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     impl ::std::ops::Deref for DiameterDimension {
         type Target = DimensionCurveDirectedCallout;
@@ -988,7 +988,7 @@ pub mod explicit_draughting {
         pub luminous_intensity_exponent: f64,
     }
     impl ::std::ops::Deref for Direction {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -997,7 +997,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Direction {
         pub direction_ratios: Vec<f64>,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Document {
@@ -1018,7 +1018,7 @@ pub mod explicit_draughting {
         pub product_data_type: Label,
     }
     impl ::std::ops::Deref for DraughtingAnnotationOccurrence {
-        type Target = AnnotationOccurrence;
+        type Target = Box<dyn AnnotationOccurrenceAny>;
         fn deref(&self) -> &Self::Target {
             &self.annotation_occurrence
         }
@@ -1026,10 +1026,10 @@ pub mod explicit_draughting {
     impl AnnotationOccurrenceAny for DraughtingAnnotationOccurrence {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingAnnotationOccurrence {
-        pub annotation_occurrence: AnnotationOccurrence,
+        pub annotation_occurrence: Box<dyn AnnotationOccurrenceAny>,
     }
     impl ::std::ops::Deref for DraughtingApprovalAssignment {
-        type Target = ApprovalAssignment;
+        type Target = Box<dyn ApprovalAssignmentAny>;
         fn deref(&self) -> &Self::Target {
             &self.approval_assignment
         }
@@ -1038,10 +1038,10 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingApprovalAssignment {
         pub approved_items: Vec<ApprovedItem>,
-        pub approval_assignment: ApprovalAssignment,
+        pub approval_assignment: Box<dyn ApprovalAssignmentAny>,
     }
     impl ::std::ops::Deref for DraughtingCallout {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -1050,7 +1050,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingCallout {
         pub contents: Vec<DraughtingCalloutElement>,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingCalloutRelationship {
@@ -1060,7 +1060,7 @@ pub mod explicit_draughting {
         pub related_draughting_callout: DraughtingCallout,
     }
     impl ::std::ops::Deref for DraughtingContractAssignment {
-        type Target = ContractAssignment;
+        type Target = Box<dyn ContractAssignmentAny>;
         fn deref(&self) -> &Self::Target {
             &self.contract_assignment
         }
@@ -1069,7 +1069,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingContractAssignment {
         pub items: Vec<ContractedItem>,
-        pub contract_assignment: ContractAssignment,
+        pub contract_assignment: Box<dyn ContractAssignmentAny>,
     }
     impl ::std::ops::Deref for DraughtingDrawingRevision {
         type Target = DrawingRevision;
@@ -1092,7 +1092,7 @@ pub mod explicit_draughting {
         pub draughting_callout: DraughtingCallout,
     }
     impl ::std::ops::Deref for DraughtingGroupAssignment {
-        type Target = GroupAssignment;
+        type Target = Box<dyn GroupAssignmentAny>;
         fn deref(&self) -> &Self::Target {
             &self.group_assignment
         }
@@ -1101,7 +1101,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingGroupAssignment {
         pub items: Vec<DraughtingGroupedItem>,
-        pub group_assignment: GroupAssignment,
+        pub group_assignment: Box<dyn GroupAssignmentAny>,
     }
     impl ::std::ops::Deref for DraughtingModel {
         type Target = Representation;
@@ -1114,7 +1114,7 @@ pub mod explicit_draughting {
         pub representation: Representation,
     }
     impl ::std::ops::Deref for DraughtingOrganizationAssignment {
-        type Target = OrganizationAssignment;
+        type Target = Box<dyn OrganizationAssignmentAny>;
         fn deref(&self) -> &Self::Target {
             &self.organization_assignment
         }
@@ -1123,10 +1123,10 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingOrganizationAssignment {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
-        pub organization_assignment: OrganizationAssignment,
+        pub organization_assignment: Box<dyn OrganizationAssignmentAny>,
     }
     impl ::std::ops::Deref for DraughtingPersonAndOrganizationAssignment {
-        type Target = PersonAndOrganizationAssignment;
+        type Target = Box<dyn PersonAndOrganizationAssignmentAny>;
         fn deref(&self) -> &Self::Target {
             &self.person_and_organization_assignment
         }
@@ -1135,10 +1135,10 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingPersonAndOrganizationAssignment {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
-        pub person_and_organization_assignment: PersonAndOrganizationAssignment,
+        pub person_and_organization_assignment: Box<dyn PersonAndOrganizationAssignmentAny>,
     }
     impl ::std::ops::Deref for DraughtingPersonAssignment {
-        type Target = PersonAssignment;
+        type Target = Box<dyn PersonAssignmentAny>;
         fn deref(&self) -> &Self::Target {
             &self.person_assignment
         }
@@ -1147,7 +1147,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingPersonAssignment {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
-        pub person_assignment: PersonAssignment,
+        pub person_assignment: Box<dyn PersonAssignmentAny>,
     }
     impl ::std::ops::Deref for DraughtingPreDefinedColour {
         type Target = PreDefinedColour;
@@ -1180,7 +1180,7 @@ pub mod explicit_draughting {
         pub pre_defined_text_font: PreDefinedTextFont,
     }
     impl ::std::ops::Deref for DraughtingPresentedItem {
-        type Target = PresentedItem;
+        type Target = Box<dyn PresentedItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.presented_item
         }
@@ -1189,10 +1189,10 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingPresentedItem {
         pub items: Vec<DraughtingPresentedItemSelect>,
-        pub presented_item: PresentedItem,
+        pub presented_item: Box<dyn PresentedItemAny>,
     }
     impl ::std::ops::Deref for DraughtingSecurityClassificationAssignment {
-        type Target = SecurityClassificationAssignment;
+        type Target = Box<dyn SecurityClassificationAssignmentAny>;
         fn deref(&self) -> &Self::Target {
             &self.security_classification_assignment
         }
@@ -1201,10 +1201,10 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingSecurityClassificationAssignment {
         pub assigned_items: Vec<ClassifiedItem>,
-        pub security_classification_assignment: SecurityClassificationAssignment,
+        pub security_classification_assignment: Box<dyn SecurityClassificationAssignmentAny>,
     }
     impl ::std::ops::Deref for DraughtingSpecificationReference {
-        type Target = DocumentReference;
+        type Target = Box<dyn DocumentReferenceAny>;
         fn deref(&self) -> &Self::Target {
             &self.document_reference
         }
@@ -1213,7 +1213,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DraughtingSpecificationReference {
         pub specified_items: Vec<SpecifiedItem>,
-        pub document_reference: DocumentReference,
+        pub document_reference: Box<dyn DocumentReferenceAny>,
     }
     impl ::std::ops::Deref for DraughtingSubfigureRepresentation {
         type Target = SymbolRepresentation;
@@ -1302,7 +1302,7 @@ pub mod explicit_draughting {
         pub area_in_set: AreaInSet,
     }
     impl ::std::ops::Deref for Ellipse {
-        type Target = Conic;
+        type Target = Box<dyn ConicAny>;
         fn deref(&self) -> &Self::Target {
             &self.conic
         }
@@ -1312,7 +1312,7 @@ pub mod explicit_draughting {
     pub struct Ellipse {
         pub semi_axis_1: PositiveLengthMeasure,
         pub semi_axis_2: PositiveLengthMeasure,
-        pub conic: Conic,
+        pub conic: Box<dyn ConicAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ExternalSource {
@@ -1332,7 +1332,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ExternallyDefinedHatchStyle {
         pub externally_defined_item: ExternallyDefinedItem,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ExternallyDefinedItem {
@@ -1363,7 +1363,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ExternallyDefinedTileStyle {
         pub externally_defined_item: ExternallyDefinedItem,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct FillAreaStyle {
@@ -1376,7 +1376,7 @@ pub mod explicit_draughting {
         pub fill_colour: Colour,
     }
     impl ::std::ops::Deref for FillAreaStyleHatching {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -1389,10 +1389,10 @@ pub mod explicit_draughting {
         pub point_of_reference_hatch_line: CartesianPoint,
         pub pattern_start: CartesianPoint,
         pub hatch_line_angle: PlaneAngleMeasure,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     impl ::std::ops::Deref for FillAreaStyleTileSymbolWithStyle {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -1401,10 +1401,10 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct FillAreaStyleTileSymbolWithStyle {
         pub symbol: AnnotationSymbolOccurrence,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     impl ::std::ops::Deref for FillAreaStyleTiles {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -1415,10 +1415,10 @@ pub mod explicit_draughting {
         pub tiling_pattern: TwoDirectionRepeatFactor,
         pub tiles: Vec<FillAreaStyleTileShapeSelect>,
         pub tiling_scale: PositiveRatioMeasure,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     impl ::std::ops::Deref for GeometricCurveSet {
-        type Target = GeometricSet;
+        type Target = Box<dyn GeometricSetAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_set
         }
@@ -1426,7 +1426,7 @@ pub mod explicit_draughting {
     impl GeometricSetAny for GeometricCurveSet {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct GeometricCurveSet {
-        pub geometric_set: GeometricSet,
+        pub geometric_set: Box<dyn GeometricSetAny>,
     }
     impl ::std::ops::Deref for GeometricRepresentationContext {
         type Target = RepresentationContext;
@@ -1452,7 +1452,7 @@ pub mod explicit_draughting {
     pub trait GeometricRepresentationItemAny: ::std::any::Any + ::std::fmt::Debug {}
     impl GeometricRepresentationItemAny for GeometricRepresentationItem {}
     impl ::std::ops::Deref for GeometricSet {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -1461,7 +1461,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct GeometricSet {
         pub elements: Vec<GeometricSetSelect>,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     pub trait GeometricSetAny: ::std::any::Any + ::std::fmt::Debug {}
     impl GeometricSetAny for GeometricSet {}
@@ -1515,7 +1515,7 @@ pub mod explicit_draughting {
         pub related_group: Group,
     }
     impl ::std::ops::Deref for Hyperbola {
-        type Target = Conic;
+        type Target = Box<dyn ConicAny>;
         fn deref(&self) -> &Self::Target {
             &self.conic
         }
@@ -1525,7 +1525,7 @@ pub mod explicit_draughting {
     pub struct Hyperbola {
         pub semi_axis: PositiveLengthMeasure,
         pub semi_imag_axis: PositiveLengthMeasure,
-        pub conic: Conic,
+        pub conic: Box<dyn ConicAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Invisibility {
@@ -1572,7 +1572,7 @@ pub mod explicit_draughting {
         pub terminator_symbol: TerminatorSymbol,
     }
     impl ::std::ops::Deref for LengthMeasureWithUnit {
-        type Target = MeasureWithUnit;
+        type Target = Box<dyn MeasureWithUnitAny>;
         fn deref(&self) -> &Self::Target {
             &self.measure_with_unit
         }
@@ -1580,10 +1580,10 @@ pub mod explicit_draughting {
     impl MeasureWithUnitAny for LengthMeasureWithUnit {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct LengthMeasureWithUnit {
-        pub measure_with_unit: MeasureWithUnit,
+        pub measure_with_unit: Box<dyn MeasureWithUnitAny>,
     }
     impl ::std::ops::Deref for LengthUnit {
-        type Target = NamedUnit;
+        type Target = Box<dyn NamedUnitAny>;
         fn deref(&self) -> &Self::Target {
             &self.named_unit
         }
@@ -1591,10 +1591,10 @@ pub mod explicit_draughting {
     impl NamedUnitAny for LengthUnit {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct LengthUnit {
-        pub named_unit: NamedUnit,
+        pub named_unit: Box<dyn NamedUnitAny>,
     }
     impl ::std::ops::Deref for Line {
-        type Target = Curve;
+        type Target = Box<dyn CurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.curve
         }
@@ -1604,7 +1604,7 @@ pub mod explicit_draughting {
     pub struct Line {
         pub pnt: CartesianPoint,
         pub dir: Vector,
-        pub curve: Curve,
+        pub curve: Box<dyn CurveAny>,
     }
     impl ::std::ops::Deref for LinearDimension {
         type Target = DimensionCurveDirectedCallout;
@@ -1642,7 +1642,7 @@ pub mod explicit_draughting {
     pub trait NamedUnitAny: ::std::any::Any + ::std::fmt::Debug {}
     impl NamedUnitAny for NamedUnit {}
     impl ::std::ops::Deref for OffsetCurve2D {
-        type Target = Curve;
+        type Target = Box<dyn CurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.curve
         }
@@ -1650,13 +1650,13 @@ pub mod explicit_draughting {
     impl CurveAny for OffsetCurve2D {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct OffsetCurve2D {
-        pub basis_curve: Curve,
+        pub basis_curve: Box<dyn CurveAny>,
         pub distance: LengthMeasure,
         pub self_intersect: Logical,
-        pub curve: Curve,
+        pub curve: Box<dyn CurveAny>,
     }
     impl ::std::ops::Deref for OneDirectionRepeatFactor {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -1665,7 +1665,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct OneDirectionRepeatFactor {
         pub repeat_factor: Vector,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     impl ::std::ops::Deref for OrdinateDimension {
         type Target = ProjectionDirectedCallout;
@@ -1707,7 +1707,7 @@ pub mod explicit_draughting {
         pub address: Address,
     }
     impl ::std::ops::Deref for Parabola {
-        type Target = Conic;
+        type Target = Box<dyn ConicAny>;
         fn deref(&self) -> &Self::Target {
             &self.conic
         }
@@ -1716,7 +1716,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Parabola {
         pub focal_dist: LengthMeasure,
-        pub conic: Conic,
+        pub conic: Box<dyn ConicAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Person {
@@ -1767,7 +1767,7 @@ pub mod explicit_draughting {
         pub address: Address,
     }
     impl ::std::ops::Deref for Placement {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -1776,7 +1776,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Placement {
         pub location: CartesianPoint,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     pub trait PlacementAny: ::std::any::Any + ::std::fmt::Debug {}
     impl PlacementAny for Placement {}
@@ -1792,7 +1792,7 @@ pub mod explicit_draughting {
         pub planar_extent: PlanarExtent,
     }
     impl ::std::ops::Deref for PlanarExtent {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -1802,10 +1802,10 @@ pub mod explicit_draughting {
     pub struct PlanarExtent {
         pub size_in_x: LengthMeasure,
         pub size_in_y: LengthMeasure,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     impl ::std::ops::Deref for PlaneAngleMeasureWithUnit {
-        type Target = MeasureWithUnit;
+        type Target = Box<dyn MeasureWithUnitAny>;
         fn deref(&self) -> &Self::Target {
             &self.measure_with_unit
         }
@@ -1813,10 +1813,10 @@ pub mod explicit_draughting {
     impl MeasureWithUnitAny for PlaneAngleMeasureWithUnit {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PlaneAngleMeasureWithUnit {
-        pub measure_with_unit: MeasureWithUnit,
+        pub measure_with_unit: Box<dyn MeasureWithUnitAny>,
     }
     impl ::std::ops::Deref for PlaneAngleUnit {
-        type Target = NamedUnit;
+        type Target = Box<dyn NamedUnitAny>;
         fn deref(&self) -> &Self::Target {
             &self.named_unit
         }
@@ -1824,10 +1824,10 @@ pub mod explicit_draughting {
     impl NamedUnitAny for PlaneAngleUnit {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PlaneAngleUnit {
-        pub named_unit: NamedUnit,
+        pub named_unit: Box<dyn NamedUnitAny>,
     }
     impl ::std::ops::Deref for Point {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -1835,12 +1835,12 @@ pub mod explicit_draughting {
     impl GeometricRepresentationItemAny for Point {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Point {
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     pub trait PointAny: ::std::any::Any + ::std::fmt::Debug {}
     impl PointAny for Point {}
     impl ::std::ops::Deref for PointOnCurve {
-        type Target = Point;
+        type Target = Box<dyn PointAny>;
         fn deref(&self) -> &Self::Target {
             &self.point
         }
@@ -1848,12 +1848,12 @@ pub mod explicit_draughting {
     impl PointAny for PointOnCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PointOnCurve {
-        pub basis_curve: Curve,
+        pub basis_curve: Box<dyn CurveAny>,
         pub point_parameter: ParameterValue,
-        pub point: Point,
+        pub point: Box<dyn PointAny>,
     }
     impl ::std::ops::Deref for Polyline {
-        type Target = BoundedCurve;
+        type Target = Box<dyn BoundedCurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.bounded_curve
         }
@@ -1862,7 +1862,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Polyline {
         pub points: Vec<CartesianPoint>,
-        pub bounded_curve: BoundedCurve,
+        pub bounded_curve: Box<dyn BoundedCurveAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PreDefinedColour {
@@ -2013,7 +2013,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PresentedItemRepresentation {
         pub presentation: PresentationRepresentationSelect,
-        pub item: PresentedItem,
+        pub item: Box<dyn PresentedItemAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Product {
@@ -2023,7 +2023,7 @@ pub mod explicit_draughting {
         pub frame_of_reference: Vec<ProductContext>,
     }
     impl ::std::ops::Deref for ProductContext {
-        type Target = ApplicationContextElement;
+        type Target = Box<dyn ApplicationContextElementAny>;
         fn deref(&self) -> &Self::Target {
             &self.application_context_element
         }
@@ -2032,7 +2032,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ProductContext {
         pub discipline_type: Label,
-        pub application_context_element: ApplicationContextElement,
+        pub application_context_element: Box<dyn ApplicationContextElementAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ProductDefinition {
@@ -2042,7 +2042,7 @@ pub mod explicit_draughting {
         pub frame_of_reference: ProductDefinitionContext,
     }
     impl ::std::ops::Deref for ProductDefinitionContext {
-        type Target = ApplicationContextElement;
+        type Target = Box<dyn ApplicationContextElementAny>;
         fn deref(&self) -> &Self::Target {
             &self.application_context_element
         }
@@ -2051,7 +2051,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ProductDefinitionContext {
         pub life_cycle_stage: Label,
-        pub application_context_element: ApplicationContextElement,
+        pub application_context_element: Box<dyn ApplicationContextElementAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ProductDefinitionFormation {
@@ -2101,7 +2101,7 @@ pub mod explicit_draughting {
         pub used_representation: Representation,
     }
     impl ::std::ops::Deref for QuasiUniformCurve {
-        type Target = BSplineCurve;
+        type Target = Box<dyn BSplineCurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.b_spline_curve
         }
@@ -2109,7 +2109,7 @@ pub mod explicit_draughting {
     impl BSplineCurveAny for QuasiUniformCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct QuasiUniformCurve {
-        pub b_spline_curve: BSplineCurve,
+        pub b_spline_curve: Box<dyn BSplineCurveAny>,
     }
     impl ::std::ops::Deref for RadiusDimension {
         type Target = DimensionCurveDirectedCallout;
@@ -2122,7 +2122,7 @@ pub mod explicit_draughting {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
     }
     impl ::std::ops::Deref for RationalBSplineCurve {
-        type Target = BSplineCurve;
+        type Target = Box<dyn BSplineCurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.b_spline_curve
         }
@@ -2131,7 +2131,7 @@ pub mod explicit_draughting {
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct RationalBSplineCurve {
         pub weights_data: Vec<f64>,
-        pub b_spline_curve: BSplineCurve,
+        pub b_spline_curve: Box<dyn BSplineCurveAny>,
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct Representation {
@@ -2190,7 +2190,7 @@ pub mod explicit_draughting {
         pub representation: Representation,
     }
     impl ::std::ops::Deref for SiUnit {
-        type Target = NamedUnit;
+        type Target = Box<dyn NamedUnitAny>;
         fn deref(&self) -> &Self::Target {
             &self.named_unit
         }
@@ -2200,7 +2200,7 @@ pub mod explicit_draughting {
     pub struct SiUnit {
         pub prefix: Option<SiPrefix>,
         pub name: SiUnitName,
-        pub named_unit: NamedUnit,
+        pub named_unit: Box<dyn NamedUnitAny>,
     }
     impl ::std::ops::Deref for StructuredDimensionCallout {
         type Target = DraughtingCallout;
@@ -2254,7 +2254,7 @@ pub mod explicit_draughting {
         pub style_of_symbol: SymbolStyleSelect,
     }
     impl ::std::ops::Deref for SymbolTarget {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -2265,7 +2265,7 @@ pub mod explicit_draughting {
         pub placement: Axis2Placement,
         pub x_scale: PositiveRatioMeasure,
         pub y_scale: PositiveRatioMeasure,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     impl ::std::ops::Deref for TerminatorSymbol {
         type Target = AnnotationSymbolOccurrence;
@@ -2279,7 +2279,7 @@ pub mod explicit_draughting {
         pub annotation_symbol_occurrence: AnnotationSymbolOccurrence,
     }
     impl ::std::ops::Deref for TextLiteral {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -2292,7 +2292,7 @@ pub mod explicit_draughting {
         pub alignment: TextAlignment,
         pub path: TextPath,
         pub font: FontSelect,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
     impl ::std::ops::Deref for TextLiteralWithAssociatedCurves {
         type Target = TextLiteral;
@@ -2302,7 +2302,7 @@ pub mod explicit_draughting {
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct TextLiteralWithAssociatedCurves {
-        pub associated_curves: Vec<Curve>,
+        pub associated_curves: Vec<Box<dyn CurveAny>>,
         pub text_literal: TextLiteral,
     }
     impl ::std::ops::Deref for TextLiteralWithBlankingBox {
@@ -2370,7 +2370,7 @@ pub mod explicit_draughting {
         pub text_style: TextStyle,
     }
     impl ::std::ops::Deref for TrimmedCurve {
-        type Target = BoundedCurve;
+        type Target = Box<dyn BoundedCurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.bounded_curve
         }
@@ -2378,12 +2378,12 @@ pub mod explicit_draughting {
     impl BoundedCurveAny for TrimmedCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct TrimmedCurve {
-        pub basis_curve: Curve,
+        pub basis_curve: Box<dyn CurveAny>,
         pub trim_1: Vec<TrimmingSelect>,
         pub trim_2: Vec<TrimmingSelect>,
         pub sense_agreement: bool,
         pub master_representation: TrimmingPreference,
-        pub bounded_curve: BoundedCurve,
+        pub bounded_curve: Box<dyn BoundedCurveAny>,
     }
     impl ::std::ops::Deref for TwoDirectionRepeatFactor {
         type Target = OneDirectionRepeatFactor;
@@ -2397,7 +2397,7 @@ pub mod explicit_draughting {
         pub one_direction_repeat_factor: OneDirectionRepeatFactor,
     }
     impl ::std::ops::Deref for UniformCurve {
-        type Target = BSplineCurve;
+        type Target = Box<dyn BSplineCurveAny>;
         fn deref(&self) -> &Self::Target {
             &self.b_spline_curve
         }
@@ -2405,10 +2405,10 @@ pub mod explicit_draughting {
     impl BSplineCurveAny for UniformCurve {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct UniformCurve {
-        pub b_spline_curve: BSplineCurve,
+        pub b_spline_curve: Box<dyn BSplineCurveAny>,
     }
     impl ::std::ops::Deref for Vector {
-        type Target = GeometricRepresentationItem;
+        type Target = Box<dyn GeometricRepresentationItemAny>;
         fn deref(&self) -> &Self::Target {
             &self.geometric_representation_item
         }
@@ -2418,6 +2418,6 @@ pub mod explicit_draughting {
     pub struct Vector {
         pub orientation: Direction,
         pub magnitude: LengthMeasure,
-        pub geometric_representation_item: GeometricRepresentationItem,
+        pub geometric_representation_item: Box<dyn GeometricRepresentationItemAny>,
     }
 }

--- a/ruststep/src/ap201.rs
+++ b/ruststep/src/ap201.rs
@@ -412,6 +412,8 @@ pub mod explicit_draughting {
     pub struct AnnotationOccurrence {
         pub styled_item: StyledItem,
     }
+    pub trait AnnotationOccurrenceAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl AnnotationOccurrenceAny for AnnotationOccurrence {}
     impl ::std::ops::Deref for AnnotationSubfigureOccurrence {
         type Target = AnnotationSymbolOccurrence;
         fn deref(&self) -> &Self::Target {
@@ -471,6 +473,8 @@ pub mod explicit_draughting {
         pub name: Label,
         pub frame_of_reference: ApplicationContext,
     }
+    pub trait ApplicationContextElementAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl ApplicationContextElementAny for ApplicationContextElement {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ApplicationProtocolDefinition {
         pub status: Label,
@@ -487,6 +491,8 @@ pub mod explicit_draughting {
     pub struct ApprovalAssignment {
         pub assigned_approval: Approval,
     }
+    pub trait ApprovalAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl ApprovalAssignmentAny for ApprovalAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ApprovalDateTime {
         pub date_time: DateTimeSelect,
@@ -537,6 +543,8 @@ pub mod explicit_draughting {
         pub self_intersect: Logical,
         pub bounded_curve: BoundedCurve,
     }
+    pub trait BSplineCurveAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl BSplineCurveAny for BSplineCurve {}
     impl ::std::ops::Deref for BSplineCurveWithKnots {
         type Target = BSplineCurve;
         fn deref(&self) -> &Self::Target {
@@ -570,6 +578,8 @@ pub mod explicit_draughting {
     pub struct BoundedCurve {
         pub curve: Curve,
     }
+    pub trait BoundedCurveAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl BoundedCurveAny for BoundedCurve {}
     impl ::std::ops::Deref for CalendarDate {
         type Target = Date;
         fn deref(&self) -> &Self::Target {
@@ -612,6 +622,8 @@ pub mod explicit_draughting {
     pub struct CameraModel {
         pub geometric_representation_item: GeometricRepresentationItem,
     }
+    pub trait CameraModelAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl CameraModelAny for CameraModel {}
     impl ::std::ops::Deref for CameraModelD2 {
         type Target = CameraModel;
         fn deref(&self) -> &Self::Target {
@@ -755,6 +767,8 @@ pub mod explicit_draughting {
         pub position: Axis2Placement,
         pub curve: Curve,
     }
+    pub trait ConicAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl ConicAny for Conic {}
     impl ::std::ops::Deref for ContextDependentInvisibility {
         type Target = Invisibility;
         fn deref(&self) -> &Self::Target {
@@ -776,6 +790,8 @@ pub mod explicit_draughting {
     pub struct ContractAssignment {
         pub assigned_contract: Contract,
     }
+    pub trait ContractAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl ContractAssignmentAny for ContractAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct ContractType {
         pub description: Label,
@@ -802,6 +818,8 @@ pub mod explicit_draughting {
     pub struct Curve {
         pub geometric_representation_item: GeometricRepresentationItem,
     }
+    pub trait CurveAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl CurveAny for Curve {}
     impl ::std::ops::Deref for CurveDimension {
         type Target = DimensionCurveDirectedCallout;
         fn deref(&self) -> &Self::Target {
@@ -833,6 +851,8 @@ pub mod explicit_draughting {
     pub struct Date {
         pub year_component: YearNumber,
     }
+    pub trait DateAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl DateAny for Date {}
     impl ::std::ops::Deref for DatumFeatureCallout {
         type Target = DraughtingCallout;
         fn deref(&self) -> &Self::Target {
@@ -969,6 +989,8 @@ pub mod explicit_draughting {
         pub assigned_document: Document,
         pub source: Label,
     }
+    pub trait DocumentReferenceAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl DocumentReferenceAny for DocumentReference {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct DocumentType {
         pub product_data_type: Label,
@@ -1387,6 +1409,8 @@ pub mod explicit_draughting {
     pub struct GeometricRepresentationItem {
         pub representation_item: RepresentationItem,
     }
+    pub trait GeometricRepresentationItemAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl GeometricRepresentationItemAny for GeometricRepresentationItem {}
     impl ::std::ops::Deref for GeometricSet {
         type Target = GeometricRepresentationItem;
         fn deref(&self) -> &Self::Target {
@@ -1398,6 +1422,8 @@ pub mod explicit_draughting {
         pub elements: Vec<GeometricSetSelect>,
         pub geometric_representation_item: GeometricRepresentationItem,
     }
+    pub trait GeometricSetAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl GeometricSetAny for GeometricSet {}
     impl ::std::ops::Deref for GeometricalToleranceCallout {
         type Target = DraughtingCallout;
         fn deref(&self) -> &Self::Target {
@@ -1438,6 +1464,8 @@ pub mod explicit_draughting {
     pub struct GroupAssignment {
         pub assigned_group: Group,
     }
+    pub trait GroupAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl GroupAssignmentAny for GroupAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct GroupRelationship {
         pub name: Label,
@@ -1560,10 +1588,14 @@ pub mod explicit_draughting {
         pub value_component: MeasureValue,
         pub unit_component: Unit,
     }
+    pub trait MeasureWithUnitAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl MeasureWithUnitAny for MeasureWithUnit {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct NamedUnit {
         pub dimensions: DimensionalExponents,
     }
+    pub trait NamedUnitAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl NamedUnitAny for NamedUnit {}
     impl ::std::ops::Deref for OffsetCurve2D {
         type Target = Curve;
         fn deref(&self) -> &Self::Target {
@@ -1609,6 +1641,8 @@ pub mod explicit_draughting {
         pub assigned_organization: Organization,
         pub role: OrganizationRole,
     }
+    pub trait OrganizationAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl OrganizationAssignmentAny for OrganizationAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct OrganizationRole {
         pub name: Label,
@@ -1655,6 +1689,8 @@ pub mod explicit_draughting {
         pub assigned_person_and_organization: PersonAndOrganization,
         pub role: PersonAndOrganizationRole,
     }
+    pub trait PersonAndOrganizationAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl PersonAndOrganizationAssignmentAny for PersonAndOrganizationAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PersonAndOrganizationRole {
         pub name: Label,
@@ -1664,6 +1700,8 @@ pub mod explicit_draughting {
         pub assigned_person: Person,
         pub role: PersonRole,
     }
+    pub trait PersonAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl PersonAssignmentAny for PersonAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PersonRole {
         pub name: Label,
@@ -1691,6 +1729,8 @@ pub mod explicit_draughting {
         pub location: CartesianPoint,
         pub geometric_representation_item: GeometricRepresentationItem,
     }
+    pub trait PlacementAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl PlacementAny for Placement {}
     impl ::std::ops::Deref for PlanarBox {
         type Target = PlanarExtent;
         fn deref(&self) -> &Self::Target {
@@ -1744,6 +1784,8 @@ pub mod explicit_draughting {
     pub struct Point {
         pub geometric_representation_item: GeometricRepresentationItem,
     }
+    pub trait PointAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl PointAny for Point {}
     impl ::std::ops::Deref for PointOnCurve {
         type Target = Point;
         fn deref(&self) -> &Self::Target {
@@ -1911,6 +1953,8 @@ pub mod explicit_draughting {
     }
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PresentedItem {}
+    pub trait PresentedItemAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl PresentedItemAny for PresentedItem {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct PresentedItemRepresentation {
         pub presentation: PresentationRepresentationSelect,
@@ -2060,6 +2104,8 @@ pub mod explicit_draughting {
     pub struct SecurityClassificationAssignment {
         pub assigned_security_classification: SecurityClassification,
     }
+    pub trait SecurityClassificationAssignmentAny: ::std::any::Any + ::std::fmt::Debug {}
+    impl SecurityClassificationAssignmentAny for SecurityClassificationAssignment {}
     #[derive(Clone, Debug, PartialEq, derive_new :: new)]
     pub struct SecurityClassificationLevel {
         pub name: Label,


### PR DESCRIPTION
Resolve #40 based on AP000 implmenetation in #50 

TODO
---------

From https://github.com/ricosjp/ruststep/pull/50#issuecomment-830578712

- [x] Generate `XxxxAny` trait if ENTITY has SUPERTYPE spec
- [x] Gnerate `impl XxxAny for SubType` if  ENTITY has SUBTYPE spec
- [x] Replace attribute type `Box<dyn XxxAny>` if the ENTITY is a supertype
  - [x] Check the entity is supertype while namespace lookup
