### PR TITLE
SingleMapDeserializer instead of de::value::Map(Access)Deserializer

### DIFF
--- a/ruststep/src/ast/mod.rs
+++ b/ruststep/src/ast/mod.rs
@@ -3,11 +3,13 @@
 mod parameter;
 mod record;
 mod ser;
+mod single_map_deserializer;
 mod value;
 
 pub use parameter::*;
 pub use record::*;
 pub use ser::*;
+pub use single_map_deserializer::*;
 pub use value::*;
 
 /// Entire exchange structure

--- a/ruststep/src/ast/parameter.rs
+++ b/ruststep/src/ast/parameter.rs
@@ -224,9 +224,9 @@ impl<'de, 'param> de::Deserializer<'de> for &'param Parameter {
         V: de::Visitor<'de>,
     {
         match self {
-            Parameter::Typed { name, ty } => visitor.visit_map(de::value::MapDeserializer::new(
-                [(name.as_str(), &**ty)].iter().cloned(),
-            )),
+            Parameter::Typed { name, ty } => {
+                visitor.visit_map(SingleMapDeserializer::new(name, ty.as_ref()))
+            }
             Parameter::Integer(val) => visitor.visit_i64(*val),
             Parameter::Real(val) => visitor.visit_f64(*val),
             Parameter::String(val) => visitor.visit_str(val),

--- a/ruststep/src/ast/record.rs
+++ b/ruststep/src/ast/record.rs
@@ -30,22 +30,7 @@ pub struct Record {
 impl<'de, 'record> de::Deserializer<'de> for &'record Record {
     type Error = Error;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
-    where
-        V: de::Visitor<'de>,
-    {
-        Err(de::Error::invalid_type(
-            de::Unexpected::Other("any"),
-            &self.name.as_str(),
-        ))
-    }
-
-    fn deserialize_struct<V>(
-        self,
-        _name: &'static str,
-        _fields: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
@@ -56,6 +41,6 @@ impl<'de, 'record> de::Deserializer<'de> for &'record Record {
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map enum identifier ignored_any
+        struct tuple_struct map enum identifier ignored_any
     }
 }

--- a/ruststep/src/ast/single_map_deserializer.rs
+++ b/ruststep/src/ast/single_map_deserializer.rs
@@ -1,0 +1,49 @@
+use serde::de::{self, IntoDeserializer};
+
+/// Deserializer corresponding to a single-key map like `{ "A": [1.0, 2.0] }`
+pub struct SingleMapDeserializer<T> {
+    key: Option<String>,
+    value: Option<T>,
+}
+
+impl<T> SingleMapDeserializer<T> {
+    pub fn new(key: &str, value: T) -> Self {
+        SingleMapDeserializer {
+            key: Some(key.to_string()),
+            value: Some(value),
+        }
+    }
+}
+
+impl<'de, T> de::MapAccess<'de> for SingleMapDeserializer<T>
+where
+    T: IntoDeserializer<'de, crate::error::Error>,
+{
+    type Error = crate::error::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        if let Some(key) = self.key.take() {
+            let key: de::value::StrDeserializer<Self::Error> = key.as_str().into_deserializer();
+            let key: K::Value = seed.deserialize(key)?;
+            Ok(Some(key))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        if let Some(value) = self.value.take() {
+            let value = value.into_deserializer();
+            let value: V::Value = seed.deserialize(value)?;
+            Ok(value)
+        } else {
+            unreachable!("next_value_seed before next_key_seed is incorrect.")
+        }
+    }
+}

--- a/ruststep/src/ast/single_map_deserializer.rs
+++ b/ruststep/src/ast/single_map_deserializer.rs
@@ -1,6 +1,7 @@
 use serde::de::{self, IntoDeserializer};
 
 /// Deserializer corresponding to a single-key map like `{ "A": [1.0, 2.0] }`
+#[derive(Debug)]
 pub struct SingleMapDeserializer<T> {
     key: Option<String>,
     value: Option<T>,
@@ -44,6 +45,80 @@ where
             Ok(value)
         } else {
             unreachable!("next_value_seed before next_key_seed is incorrect.")
+        }
+    }
+}
+
+// As serde document says,
+//
+// https://docs.serde.rs/serde/de/trait.VariantAccess.html
+//
+// > VariantAccess is a visitor that is created by the Deserializer
+// > and passed to the Deserialize to deserialize the content of a particular enum variant.
+//
+// this trait is used for 4 data models:
+//
+// - "unit_variant"    e.g. the `E::A` and `E::B` in `enum E { A, B }`
+// - "newtype_variant" e.g. the `E::N` in `enum E { N(u8) }`
+// - "tuple_variant"   e.g. the `E::T` in `enum E { T(u8, u8) }`
+// - "struct_variant"  e.g. the `E::S` in `enum E { S { r: u8, g: u8, b: u8 } }`
+//
+// But, `SingleMapDeserializer` is only used for "newtype_variant" case,
+// and returns `Err` in other cases.
+//
+impl<'de, T> de::VariantAccess<'de> for SingleMapDeserializer<T>
+where
+    T: IntoDeserializer<'de, crate::error::Error>,
+{
+    type Error = crate::error::Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        let unexp = de::Unexpected::Map;
+        Err(de::Error::invalid_type(unexp, &"unit variant"))
+    }
+
+    fn newtype_variant_seed<D>(mut self, seed: D) -> Result<D::Value, Self::Error>
+    where
+        D: de::DeserializeSeed<'de>,
+    {
+        de::MapAccess::next_value_seed(&mut self, seed)
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        let unexp = de::Unexpected::Map;
+        Err(de::Error::invalid_type(unexp, &"tuple variant"))
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        let unexp = de::Unexpected::Map;
+        Err(de::Error::invalid_type(unexp, &"struct variant"))
+    }
+}
+
+impl<'de, T> de::EnumAccess<'de> for SingleMapDeserializer<T>
+where
+    T: IntoDeserializer<'de, crate::error::Error>,
+{
+    type Error = crate::error::Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        match de::MapAccess::next_key_seed(&mut self, seed)? {
+            Some(key) => Ok((key, self)),
+            None => Err(de::Error::invalid_type(de::Unexpected::Map, &"enum")),
         }
     }
 }

--- a/ruststep/src/ast/value.rs
+++ b/ruststep/src/ast/value.rs
@@ -1,3 +1,4 @@
+use super::SingleMapDeserializer;
 use serde::{de, forward_to_deserialize_any, Deserialize};
 
 #[cfg(doc)] // for doc-link
@@ -72,22 +73,14 @@ impl<'de, 'value> de::Deserializer<'de> for &'value RValue {
         V: de::Visitor<'de>,
     {
         match self {
-            RValue::Entity(id) => visitor.visit_enum(de::value::MapAccessDeserializer::new(
-                de::value::MapDeserializer::new([("Entity", *id)].iter().cloned()),
-            )),
-            RValue::Value(id) => visitor.visit_enum(de::value::MapAccessDeserializer::new(
-                de::value::MapDeserializer::new([("Value", *id)].iter().cloned()),
-            )),
-            RValue::ConstantEntity(name) => visitor.visit_enum(
-                de::value::MapAccessDeserializer::new(de::value::MapDeserializer::new(
-                    [("ConstantEntity", name.clone())].iter().cloned(),
-                )),
-            ),
-            RValue::ConstantValue(name) => visitor.visit_enum(
-                de::value::MapAccessDeserializer::new(de::value::MapDeserializer::new(
-                    [("ConstantValue", name.clone())].iter().cloned(),
-                )),
-            ),
+            RValue::Entity(id) => visitor.visit_enum(SingleMapDeserializer::new("Entity", *id)),
+            RValue::Value(id) => visitor.visit_enum(SingleMapDeserializer::new("Value", *id)),
+            RValue::ConstantEntity(name) => {
+                visitor.visit_enum(SingleMapDeserializer::new("ConstantEntity", name.clone()))
+            }
+            RValue::ConstantValue(name) => {
+                visitor.visit_enum(SingleMapDeserializer::new("ConstantValue", name.clone()))
+            }
         }
     }
 

--- a/ruststep/src/place_holder.rs
+++ b/ruststep/src/place_holder.rs
@@ -47,7 +47,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for PlaceHolder<T> {
         // > RValue::deserialize_struct(PlaceHolderVisitor)
         // > (forward_to_deserialize_any)
         // > RValue::deserialize_any(PlaceHolderVisitor)
-        // > PlaceHolderVisitor::visit_enum(MapAccessDeserializer)
+        // > PlaceHolderVisitor::visit_enum(SingleMapDeserializer)
         //
         // For Owned(T)
         // -------------


### PR DESCRIPTION
Revival of #62, focusing on refactoring i.e. without changing deserialization behavior.