### PR TITLE
Flatten espr::ast::* modules

### DIFF
--- a/espr/src/ast/mod.rs
+++ b/espr/src/ast/mod.rs
@@ -1,12 +1,17 @@
 //! Abstract Syntax Tree (AST) of EXPRESS Language
 
-pub mod algorithm;
-pub mod entity;
-pub mod expression;
-pub mod schema;
-pub mod types;
+mod algorithm;
+mod entity;
+mod expression;
+mod schema;
+mod types;
 
-use crate::ast::schema::Schema;
+pub use algorithm::*;
+pub use entity::*;
+pub use expression::*;
+pub use schema::*;
+pub use types::*;
+
 use crate::parser::{combinator::*, *};
 use nom::Finish;
 

--- a/espr/src/codegen/rust/mod.rs
+++ b/espr/src/codegen/rust/mod.rs
@@ -104,7 +104,7 @@ impl ToTokens for TypeDecl {
 
 impl ToTokens for SimpleType {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        use crate::ast::types::SimpleType::*;
+        use crate::ast::SimpleType::*;
         match self.0 {
             Number => tokens.append(format_ident!("f64")),
             Real => tokens.append(format_ident!("f64")),

--- a/espr/src/parser/entity/attribute.rs
+++ b/espr/src/parser/entity/attribute.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::entity::*,
+    ast::*,
     parser::{combinator::*, expression::*, identifier::*},
 };
 

--- a/espr/src/parser/entity/derive.rs
+++ b/espr/src/parser/entity/derive.rs
@@ -1,6 +1,6 @@
 use super::attribute::*;
 use crate::{
-    ast::entity::*,
+    ast::*,
     parser::{combinator::*, expression::*, types::*},
 };
 

--- a/espr/src/parser/entity/domain.rs
+++ b/espr/src/parser/entity/domain.rs
@@ -1,5 +1,5 @@
 use super::super::{combinator::*, expression::*, identifier::*};
-use crate::ast::algorithm::*;
+use crate::ast::*;
 
 /// 338 where_clause = WHERE [domain_rule] `;` { [domain_rule] `;` } .
 pub fn where_clause(input: &str) -> ParseResult<WhereClause> {

--- a/espr/src/parser/entity/entity.rs
+++ b/espr/src/parser/entity/entity.rs
@@ -1,6 +1,6 @@
 use super::{attribute::*, derive::*, domain::*, inverse::*, unique::*};
 use crate::{
-    ast::entity::*,
+    ast::*,
     parser::{combinator::*, identifier::*, subsuper::*, types::*},
 };
 
@@ -91,7 +91,6 @@ pub fn entity_decl(input: &str) -> ParseResult<Entity> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::types::*;
     use nom::Finish;
 
     #[test]

--- a/espr/src/parser/entity/inverse.rs
+++ b/espr/src/parser/entity/inverse.rs
@@ -1,6 +1,6 @@
 use super::attribute::*;
 use crate::{
-    ast::entity::*,
+    ast::*,
     parser::{combinator::*, identifier::*, types::*},
 };
 
@@ -64,7 +64,7 @@ pub fn inverse_attr(input: &str) -> ParseResult<InverseAttribute> {
 #[cfg(test)]
 mod tests {
     use super::AggregationOption;
-    use crate::ast::{expression::*, types::*};
+    use crate::ast::*;
     use nom::Finish;
 
     #[test]

--- a/espr/src/parser/entity/unique.rs
+++ b/espr/src/parser/entity/unique.rs
@@ -1,6 +1,6 @@
 use super::attribute::*;
 use crate::{
-    ast::entity::*,
+    ast::*,
     parser::{combinator::*, identifier::*},
 };
 

--- a/espr/src/parser/expression/aggregate_initializer.rs
+++ b/espr/src/parser/expression/aggregate_initializer.rs
@@ -1,5 +1,5 @@
 use super::{super::combinator::*, *};
-use crate::ast::expression::*;
+use crate::ast::*;
 
 /// 169 aggregate_initializer = `[` \[ [element] { `,` [element] } \] `]` .
 pub fn aggregate_initializer(input: &str) -> ParseResult<Expression> {

--- a/espr/src/parser/expression/operator.rs
+++ b/espr/src/parser/expression/operator.rs
@@ -1,5 +1,5 @@
 use super::super::combinator::*;
-use crate::ast::expression::*;
+use crate::ast::*;
 
 /// 282 rel_op = `<` | `>` | `<=` | `>=` | `<>` | `=` | `:<>:` | `:=:` .
 pub fn rel_op(input: &str) -> ParseResult<RelationOperator> {

--- a/espr/src/parser/expression/primary.rs
+++ b/espr/src/parser/expression/primary.rs
@@ -3,7 +3,7 @@ use super::{
     aggregate_initializer::*,
     simple::*,
 };
-use crate::ast::expression::*;
+use crate::ast::*;
 
 /// 269 primary = [literal] | ( [qualifiable_factor] { [qualifier] } ) .
 pub fn primary(input: &str) -> ParseResult<Expression> {
@@ -216,7 +216,7 @@ pub fn built_in_constant(input: &str) -> ParseResult<BuiltInConstant> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Expression, FunctionCallName, QualifiableFactor, Qualifier};
+    use crate::ast::*;
     use nom::Finish;
 
     #[test]

--- a/espr/src/parser/expression/simple.rs
+++ b/espr/src/parser/expression/simple.rs
@@ -4,7 +4,7 @@ use super::{
     operator::*,
     primary::*,
 };
-use crate::ast::expression::*;
+use crate::ast::*;
 
 /// Create left-joined tree `1.0 + 2.0 - 3.0` into `(- (+ 1.0 2.0) 3.0)`
 fn create_tree(mut head: Expression, tails: Vec<(BinaryOperator, Expression)>) -> Expression {

--- a/espr/src/parser/literal.rs
+++ b/espr/src/parser/literal.rs
@@ -1,5 +1,5 @@
 use super::{basis::*, combinator::*};
-use crate::ast::expression::*;
+use crate::ast::*;
 
 /// 251 literal = binary_literal | [logical_literal] | [real_literal] | [string_literal] .
 ///

--- a/espr/src/parser/schema.rs
+++ b/espr/src/parser/schema.rs
@@ -1,7 +1,7 @@
 use super::{
     combinator::*, entity::*, expression::*, identifier::*, stmt::*, subsuper::*, types::*,
 };
-use crate::ast::{algorithm::*, schema::*, types::*};
+use crate::ast::*;
 
 /// 296 schema_decl = SCHEMA [schema_id] \[ schema_version_id \] `;` [schema_body] END_SCHEMA `;` .
 pub fn schema_decl(input: &str) -> ParseResult<Schema> {

--- a/espr/src/parser/stmt.rs
+++ b/espr/src/parser/stmt.rs
@@ -1,5 +1,5 @@
 use super::{combinator::*, expression::*, identifier::*, types::*};
-use crate::ast::{algorithm::*, expression::*};
+use crate::ast::*;
 
 /// 309 stmt = [alias_stmt] | [assignment_stmt] | [case_stmt] | [compound_stmt] | [escape_stmt] | [if_stmt] | [null_stmt] | [procedure_call_stmt] | [repeat_stmt] | [return_stmt] | [skip_stmt] .
 pub fn stmt(input: &str) -> ParseResult<Statement> {

--- a/espr/src/parser/subsuper.rs
+++ b/espr/src/parser/subsuper.rs
@@ -1,5 +1,5 @@
 use super::{combinator::*, identifier::*};
-use crate::ast::entity::*;
+use crate::ast::*;
 
 /// 164 abstract_entity_declaration = ABSTRACT .
 pub fn abstract_entity_declaration(input: &str) -> ParseResult<Constraint> {

--- a/espr/src/parser/types/concrete.rs
+++ b/espr/src/parser/types/concrete.rs
@@ -2,7 +2,7 @@ use super::{
     super::{combinator::*, expression::*, identifier::*},
     *,
 };
-use crate::ast::expression::*;
+use crate::ast::*;
 
 /// 193 concrete_types = [aggregation_types] | [simple_types] | [type_ref].
 pub fn concrete_types(input: &str) -> ParseResult<UnderlyingType> {

--- a/espr/src/parser/types/enumeration.rs
+++ b/espr/src/parser/types/enumeration.rs
@@ -1,7 +1,5 @@
-use super::{
-    super::{combinator::*, identifier::*},
-    *,
-};
+use super::super::{combinator::*, identifier::*};
+use crate::ast::*;
 
 /// 211 enumeration_items = `(` [enumeration_id] { `,` [enumeration_id] } `)` .
 pub fn enumeration_items(input: &str) -> ParseResult<Vec<String>> {

--- a/espr/src/parser/types/generalized.rs
+++ b/espr/src/parser/types/generalized.rs
@@ -2,6 +2,7 @@ use super::{
     super::{combinator::*, identifier::*},
     *,
 };
+use crate::ast::*;
 
 /// 258 named_types = [entity_ref] | [type_ref] .
 pub fn named_types(input: &str) -> ParseResult<String> {
@@ -137,7 +138,7 @@ pub fn general_set_type(input: &str) -> ParseResult<ParameterType> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::expression::Expression;
+    use crate::ast::Expression;
     use nom::Finish;
 
     #[test]

--- a/espr/src/parser/types/mod.rs
+++ b/espr/src/parser/types/mod.rs
@@ -11,7 +11,7 @@ pub use select::*;
 pub use simple::*;
 
 use super::{combinator::*, entity::*, identifier::*};
-use crate::ast::types::*;
+use crate::ast::*;
 
 /// 198 constructed_types = [enumeration_type] | [select_type] .
 pub fn constructed_types(input: &str) -> ParseResult<UnderlyingType> {

--- a/espr/src/parser/types/select.rs
+++ b/espr/src/parser/types/select.rs
@@ -1,7 +1,5 @@
-use super::{
-    super::{combinator::*, types::named_types},
-    *,
-};
+use super::{super::combinator::*, *};
+use crate::ast::*;
 
 /// 301 select_list = `(` [named_types] { `,` [named_types] } `)` .
 pub fn select_list(input: &str) -> ParseResult<Vec<String>> {

--- a/espr/src/parser/types/simple.rs
+++ b/espr/src/parser/types/simple.rs
@@ -1,5 +1,5 @@
 use super::super::combinator::*;
-use crate::ast::types::*;
+use crate::ast::*;
 
 /// 307 simple_types = [binary_type] | [boolean_type] | [integer_type] | [logical_type] | [number_type] | [real_type] | [string_type] .
 pub fn simple_types(input: &str) -> ParseResult<SimpleType> {
@@ -73,7 +73,7 @@ pub fn width_spec(input: &str) -> ParseResult<WidthSpec> {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::types::{SimpleType, WidthSpec};
+    use crate::ast::{SimpleType, WidthSpec};
     use nom::Finish;
 
     #[test]

--- a/espr/src/semantics/entity.rs
+++ b/espr/src/semantics/entity.rs
@@ -19,12 +19,12 @@ pub struct EntityAttribute {
 }
 
 impl Legalize for EntityAttribute {
-    type Input = ast::entity::EntityAttribute;
+    type Input = ast::EntityAttribute;
 
     fn legalize(ns: &Namespace, scope: &Scope, attr: &Self::Input) -> Result<Self, SemanticError> {
         let ty = TypeRef::legalize(ns, scope, &attr.ty)?;
         let name = match &attr.name {
-            ast::entity::AttributeDecl::Reference(name) => name.clone(),
+            ast::AttributeDecl::Reference(name) => name.clone(),
             _ => unimplemented!(),
         };
         Ok(EntityAttribute {
@@ -36,7 +36,7 @@ impl Legalize for EntityAttribute {
 }
 
 impl Legalize for Entity {
-    type Input = ast::entity::Entity;
+    type Input = ast::Entity;
 
     fn legalize(
         ns: &Namespace,

--- a/espr/src/semantics/namespace.rs
+++ b/espr/src/semantics/namespace.rs
@@ -64,7 +64,7 @@ impl Namespace {
             let mut enumeration_types = Vec::new();
             let mut select_types = Vec::new();
             for ty in &schema.types {
-                use ast::types::UnderlyingType;
+                use ast::UnderlyingType;
                 match &ty.underlying_type {
                     UnderlyingType::Simple(..) => simple_types.push(ty.type_id.clone()),
                     UnderlyingType::Reference(underlying_type) => {
@@ -98,7 +98,7 @@ impl Namespace {
                 current_scope = current_scope.pushed(ScopeType::Entity, &entity.name);
                 let attr_names =
                     Names::from_attributes(entity.attributes.iter().map(|attr| match &attr.name {
-                        ast::entity::AttributeDecl::Reference(name) => name.clone(),
+                        ast::AttributeDecl::Reference(name) => name.clone(),
                         _ => unimplemented!(),
                     }));
                 names.insert(current_scope.clone(), attr_names);

--- a/espr/src/semantics/schema.rs
+++ b/espr/src/semantics/schema.rs
@@ -9,7 +9,7 @@ pub struct Schema {
 }
 
 impl Legalize for Schema {
-    type Input = ast::schema::Schema;
+    type Input = ast::Schema;
     fn legalize(
         ns: &Namespace,
         scope: &Scope,

--- a/espr/src/semantics/type_decl.rs
+++ b/espr/src/semantics/type_decl.rs
@@ -42,13 +42,13 @@ pub enum TypeDecl {
 }
 
 impl Legalize for TypeDecl {
-    type Input = ast::types::TypeDecl;
+    type Input = ast::TypeDecl;
     fn legalize(
         ns: &Namespace,
         scope: &Scope,
         type_decl: &Self::Input,
     ) -> Result<Self, SemanticError> {
-        use ast::types::UnderlyingType;
+        use ast::UnderlyingType;
         let id = type_decl.type_id.clone();
         Ok(match &type_decl.underlying_type {
             UnderlyingType::Simple(ty) => TypeDecl::Simple(Simple {

--- a/espr/src/semantics/type_ref.rs
+++ b/espr/src/semantics/type_ref.rs
@@ -2,10 +2,10 @@ use super::{namespace::*, scope::*, *};
 use crate::ast;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SimpleType(pub ast::types::SimpleType);
+pub struct SimpleType(pub ast::SimpleType);
 
 impl Legalize for SimpleType {
-    type Input = ast::types::SimpleType;
+    type Input = ast::SimpleType;
     fn legalize(
         _ns: &Namespace,
         _scope: &Scope,
@@ -19,7 +19,7 @@ impl Legalize for SimpleType {
 pub struct Bound {}
 
 impl Legalize for Bound {
-    type Input = ast::types::Bound;
+    type Input = ast::Bound;
     fn legalize(
         _ns: &Namespace,
         _scope: &Scope,
@@ -81,14 +81,14 @@ impl TypeRef {
 }
 
 impl Legalize for TypeRef {
-    type Input = ast::types::ParameterType;
+    type Input = ast::ParameterType;
 
     fn legalize(
         ns: &Namespace,
         scope: &Scope,
-        ty: &ast::types::ParameterType,
+        ty: &ast::ParameterType,
     ) -> Result<Self, SemanticError> {
-        use ast::types::ParameterType::*;
+        use ast::ParameterType::*;
         Ok(match ty {
             Simple(ty) => Self::SimpleType(SimpleType(*ty)),
             Named(name) => ns.lookup_type(scope, name)?,


### PR DESCRIPTION
like as `espr::parser::*` and `espr::semantics::*`