### PR TITLE
Added reserved check to identifier parser

### DIFF
--- a/espr/src/parser/basis.rs
+++ b/espr/src/parser/basis.rs
@@ -1,4 +1,4 @@
-use super::combinator::RawParseResult;
+use super::{combinator::RawParseResult, reserved::is_reserved};
 use nom::{branch::*, character::complete::*, multi::*, sequence::*, Parser};
 
 /// 128 letter = `a` | `b` | `c` | `d` | `e` | `f` | `g` | `h` | `i` | `j` | `k` | `l` |`m` | `n` | `o` | `p` | `q` | `r` | `s` | `t` | `u` | `v` | `w` | `x` |`y` | `z` .
@@ -55,10 +55,22 @@ pub fn simple_string_literal(input: &str) -> RawParseResult<String> {
 }
 
 /// 143 simple_id = [letter] { [letter] | [digit] | `_` } .
+/// According to the standard, identifiers cannot be reserved keywords.
 pub fn simple_id(input: &str) -> RawParseResult<String> {
-    tuple((letter, many0(alt((letter, digit, char('_'))))))
-        .map(|(head, tail)| format!("{}{}", head, tail.into_iter().collect::<String>()))
+    if let Ok((input, id)) = tuple((letter, many0(alt((letter, digit, char('_'))))))
+        .map(|(head, tail)| {
+            format!("{}{}", head, tail.into_iter().collect::<String>())
+        })
         .parse(input)
+    {
+        if is_reserved(id.as_str()) {
+            Err(nom::Err::Error(nom::error::VerboseError { errors: Vec::new()}))
+        } else {
+            Ok((input, id))
+        }
+    } else {
+        Err(nom::Err::Error(nom::error::VerboseError { errors: Vec::new()}))
+    }
 }
 
 #[cfg(test)]
@@ -107,6 +119,8 @@ mod tests {
         assert_eq!(residual, "");
     }
 
+
+
     #[test]
     fn simple_id_valid() {
         let (residual, id) = super::simple_id("h").finish().unwrap();
@@ -136,5 +150,8 @@ mod tests {
         assert!(super::simple_id("1homhom").finish().is_err());
         // Empty is invlaid
         assert!(super::simple_id("").finish().is_err());
+        // IDs cannot consist of reserved keywords
+        assert!(super::simple_id("end").finish().is_err());
+        assert!(super::simple_id("end_entity").finish().is_err());
     }
 }

--- a/espr/src/parser/mod.rs
+++ b/espr/src/parser/mod.rs
@@ -46,6 +46,7 @@ mod schema;
 mod stmt;
 mod subsuper;
 mod types;
+mod reserved;
 
 pub use basis::*;
 pub use entity::*;

--- a/espr/src/parser/reserved.rs
+++ b/espr/src/parser/reserved.rs
@@ -1,0 +1,95 @@
+pub const KEYWORDS: &'static [&'static str] = &[
+    "abstract",
+    "aggregate",
+    "alias",
+    "array",
+    "as",
+    "bag",
+    "based",
+    "on",
+    "begin",
+    "binary",
+    "boolean",
+    "by",
+    "case",
+    "constant",
+    "derive",
+    "else",
+    "end",
+    "end_alias",
+    "end_case", 
+    "end_constant", 
+    "end_entity",
+    "end_function", 
+    "end_if", 
+    "end_local", 
+    "end_procedure",
+    "end_repeat", 
+    "end_rule", 
+    "end_schema", 
+    "end_subtype_constraint",
+    "end_type", 
+    "entity", 
+    "enumeration", 
+    "escape",
+    "extensible", 
+    "fixed", 
+    "for", 
+    "from",
+    "function", 
+    "generic", 
+    "generic_entity", 
+    "if",
+    "integer", 
+    "inverse", 
+    "list", 
+    "local",
+    "logical", 
+    "number", 
+    "of", 
+    "oneof",
+    "optional", 
+    "otherwise", 
+    "procedure", 
+    "query",
+    "real", 
+    "renamed", 
+    "reference", 
+    "repeat",
+    "return", 
+    "rule", 
+    "schema", 
+    "select",
+    "set", 
+    "skip", 
+    "string", 
+    "subtype",
+    "constraint", 
+    "supertype", 
+    "then", 
+    "to",
+    "total_over", 
+    "type", 
+    "unique", 
+    "until",
+    "use", 
+    "var", 
+    "where", 
+    "while",
+    "with",];
+
+pub fn is_reserved(input: &str) -> bool {
+    KEYWORDS.iter().any(|&keyword| keyword == input.to_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn is_reserved() {
+        assert!(super::is_reserved("end"));
+        assert!(!super::is_reserved(""));
+        assert!(super::is_reserved("end_entity"));
+        assert!(super::is_reserved("END_ENTITY"));
+        assert!(!super::is_reserved("end_homhom"));
+    }
+}


### PR DESCRIPTION
This pull request adds a check to simple_id that prevents reserved keywords defined in the standard being used as identifiers. This check if necessary to differentiate between identifiers and actual keywords when case insensitivity is allowed as defined in the standard.

It is a small part of #66 that should be easy to check for validity.