### PR TITLE
Unify `ast::UnderlyingType` and `ast::ParameterType` into `ast::Type`

### DIFF
--- a/espr/src/ast/algorithm.rs
+++ b/espr/src/ast/algorithm.rs
@@ -108,7 +108,7 @@ pub struct FormalParameter {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Constant {
     pub name: String,
-    pub ty: UnderlyingType,
+    pub ty: ParameterType,
     pub expr: Expression,
 }
 

--- a/espr/src/ast/algorithm.rs
+++ b/espr/src/ast/algorithm.rs
@@ -85,7 +85,7 @@ pub struct Function {
     pub constants: Vec<Constant>,
     pub variables: Vec<LocalVariable>,
     pub statements: Vec<Statement>,
-    pub return_type: ParameterType,
+    pub return_type: Type,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -100,7 +100,7 @@ pub enum ProcedureCallName {
 #[derive(Debug, Clone, PartialEq)]
 pub struct FormalParameter {
     pub name: String,
-    pub ty: ParameterType,
+    pub ty: Type,
     /// `true` if specified with `VAR` in `PROCEDURE`. Always `false` for `FUNCTION`
     pub is_variable: bool,
 }
@@ -108,7 +108,7 @@ pub struct FormalParameter {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Constant {
     pub name: String,
-    pub ty: ParameterType,
+    pub ty: Type,
     pub expr: Expression,
 }
 
@@ -126,7 +126,7 @@ pub struct Rule {
 #[derive(Debug, Clone, PartialEq)]
 pub struct LocalVariable {
     pub name: String,
-    pub ty: ParameterType,
+    pub ty: Type,
     pub expr: Option<Expression>,
 }
 

--- a/espr/src/ast/entity.rs
+++ b/espr/src/ast/entity.rs
@@ -74,7 +74,7 @@ impl<'a> PartialEq<&'a str> for AttributeDecl {
 #[derive(Debug, Clone, PartialEq)]
 pub struct EntityAttribute {
     pub name: AttributeDecl,
-    pub ty: ParameterType,
+    pub ty: Type,
     pub optional: bool,
 }
 
@@ -86,7 +86,7 @@ pub struct DeriveClause {
 #[derive(Debug, Clone, PartialEq)]
 pub struct DerivedAttribute {
     pub attr: AttributeDecl,
-    pub ty: ParameterType,
+    pub ty: Type,
     pub expr: Expression,
 }
 

--- a/espr/src/ast/types.rs
+++ b/espr/src/ast/types.rs
@@ -9,45 +9,8 @@ use crate::parser::*;
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypeDecl {
     pub type_id: String,
-    pub underlying_type: UnderlyingType,
+    pub underlying_type: ParameterType,
     pub where_clause: Option<WhereClause>,
-}
-
-/// Underlying type of a type declaration
-#[derive(Debug, Clone, PartialEq)]
-pub enum UnderlyingType {
-    // Concrete Types
-    Simple(SimpleType),
-    Reference(String),
-    Set {
-        base: Box<UnderlyingType>,
-        bound: Option<Bound>,
-    },
-    Bag {
-        base: Box<UnderlyingType>,
-        bound: Option<Bound>,
-    },
-    List {
-        base: Box<UnderlyingType>,
-        bound: Option<Bound>,
-        unique: bool,
-    },
-    Array {
-        base: Box<UnderlyingType>,
-        bound: Option<Bound>,
-        unique: bool,
-        optional: bool,
-    },
-
-    // Constructed Types
-    Enumeration {
-        extensibility: Extensibility,
-        items: Vec<String>,
-    },
-    Select {
-        extensibility: Extensibility,
-        types: Vec<String>,
-    },
 }
 
 /// Parameter type appears when *using* the type
@@ -76,11 +39,21 @@ pub enum ParameterType {
         optional: bool,
     },
 
+    // Constructed Types
+    Enumeration {
+        extensibility: Extensibility,
+        items: Vec<String>,
+    },
+    Select {
+        extensibility: Extensibility,
+        types: Vec<String>,
+    },
+
+    // Parameter Types
     Aggregate {
         base: Box<ParameterType>,
         label: Option<String>,
     },
-
     GenericEntity(Option<String>),
     Generic(Option<String>),
 }

--- a/espr/src/ast/types.rs
+++ b/espr/src/ast/types.rs
@@ -34,7 +34,7 @@ pub enum UnderlyingType {
     },
     Array {
         base: Box<UnderlyingType>,
-        bound: Bound,
+        bound: Option<Bound>,
         unique: bool,
         optional: bool,
     },

--- a/espr/src/ast/types.rs
+++ b/espr/src/ast/types.rs
@@ -9,31 +9,31 @@ use crate::parser::*;
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypeDecl {
     pub type_id: String,
-    pub underlying_type: ParameterType,
+    pub underlying_type: Type,
     pub where_clause: Option<WhereClause>,
 }
 
 /// Parameter type appears when *using* the type
 /// e.g. in attribute definition, function parameter, and so on.
 #[derive(Debug, Clone, PartialEq)]
-pub enum ParameterType {
+pub enum Type {
     Simple(SimpleType),
     Named(String),
     Set {
-        base: Box<ParameterType>,
+        base: Box<Type>,
         bound: Option<Bound>,
     },
     Bag {
-        base: Box<ParameterType>,
+        base: Box<Type>,
         bound: Option<Bound>,
     },
     List {
-        base: Box<ParameterType>,
+        base: Box<Type>,
         bound: Option<Bound>,
         unique: bool,
     },
     Array {
-        base: Box<ParameterType>,
+        base: Box<Type>,
         bound: Option<Bound>,
         unique: bool,
         optional: bool,
@@ -51,7 +51,7 @@ pub enum ParameterType {
 
     // Parameter Types
     Aggregate {
-        base: Box<ParameterType>,
+        base: Box<Type>,
         label: Option<String>,
     },
     GenericEntity(Option<String>),

--- a/espr/src/parser/entity/entity.rs
+++ b/espr/src/parser/entity/entity.rs
@@ -165,7 +165,7 @@ mod tests {
         assert_eq!(attrs.len(), 1);
         let attr = &attrs[0];
         assert_eq!(attr.name, "x");
-        assert!(matches!(attr.ty, ParameterType::Simple(SimpleType::Real)));
+        assert!(matches!(attr.ty, Type::Simple(SimpleType::Real)));
     }
 
     #[test]
@@ -175,10 +175,10 @@ mod tests {
         assert_eq!(attrs.len(), 2);
         let attr = &attrs[0];
         assert_eq!(attr.name, "x");
-        assert!(matches!(attr.ty, ParameterType::Simple(SimpleType::Real)));
+        assert!(matches!(attr.ty, Type::Simple(SimpleType::Real)));
         let attr = &attrs[1];
         assert_eq!(attr.name, "y");
-        assert!(matches!(attr.ty, ParameterType::Simple(SimpleType::Real)));
+        assert!(matches!(attr.ty, Type::Simple(SimpleType::Real)));
     }
 
     #[test]
@@ -189,7 +189,7 @@ mod tests {
         assert_eq!(attrs.len(), 1);
         let attr = &attrs[0];
         assert_eq!(attr.name, "x");
-        assert!(matches!(attr.ty, ParameterType::Simple(SimpleType::Real)));
+        assert!(matches!(attr.ty, Type::Simple(SimpleType::Real)));
         assert!(attr.optional);
     }
 
@@ -209,12 +209,12 @@ mod tests {
         assert_eq!(entity.attributes.len(), 2);
         // check `m_ref`
         assert_eq!(entity.attributes[0].name, "m_ref");
-        assert!(matches!(entity.attributes[0].ty, ParameterType::Named(_)));
+        assert!(matches!(entity.attributes[0].ty, Type::Named(_)));
         // check `fattr`
         assert_eq!(entity.attributes[1].name, "fattr");
         assert!(matches!(
             entity.attributes[1].ty,
-            ParameterType::Simple(SimpleType::Real)
+            Type::Simple(SimpleType::Real)
         ));
 
         assert_eq!(residual, "");

--- a/espr/src/parser/schema.rs
+++ b/espr/src/parser/schema.rs
@@ -161,7 +161,7 @@ pub fn function_decl(input: &str) -> ParseResult<Function> {
 /// 221 function_head = FUNCTION [function_id]
 ///                   \[ `(` [formal_parameter] { `;` [formal_parameter] } `)` \]
 ///                   `:` [parameter_type] `;` .
-pub fn function_head(input: &str) -> ParseResult<(String, Vec<FormalParameter>, ParameterType)> {
+pub fn function_head(input: &str) -> ParseResult<(String, Vec<FormalParameter>, Type)> {
     tuple((
         tag("FUNCTION"),
         function_id,

--- a/espr/src/parser/types/concrete.rs
+++ b/espr/src/parser/types/concrete.rs
@@ -31,7 +31,7 @@ pub fn array_type(input: &str) -> ParseResult<UnderlyingType> {
     ))
     .map(
         |(_set, bound, _of, optional, unique, base)| UnderlyingType::Array {
-            bound,
+            bound: Some(bound), // Maybe None for general_array_type
             unique: unique.is_some(),
             optional: optional.is_some(),
             base: Box::new(base),

--- a/espr/src/parser/types/concrete.rs
+++ b/espr/src/parser/types/concrete.rs
@@ -5,22 +5,22 @@ use super::{
 use crate::ast::*;
 
 /// 193 concrete_types = [aggregation_types] | [simple_types] | [type_ref].
-pub fn concrete_types(input: &str) -> ParseResult<UnderlyingType> {
+pub fn concrete_types(input: &str) -> ParseResult<ParameterType> {
     alt((
         aggregation_types,
-        simple_types.map(|ty| UnderlyingType::Simple(ty)),
-        type_ref.map(|s| UnderlyingType::Reference(s)),
+        simple_types.map(|ty| ParameterType::Simple(ty)),
+        type_ref.map(|s| ParameterType::Named(s)),
     ))
     .parse(input)
 }
 
 /// 172 aggregation_types = [array_type] | [bag_type] | [list_type] | [set_type] .
-pub fn aggregation_types(input: &str) -> ParseResult<UnderlyingType> {
+pub fn aggregation_types(input: &str) -> ParseResult<ParameterType> {
     alt((array_type, bag_type, list_type, set_type)).parse(input)
 }
 
 /// 175 array_type = ARRAY [bound_spec] OF \[ OPTIONAL \] \[ UNIQUE \] [instantiable_type] .
-pub fn array_type(input: &str) -> ParseResult<UnderlyingType> {
+pub fn array_type(input: &str) -> ParseResult<ParameterType> {
     tuple((
         tag("ARRAY"),
         bound_spec,
@@ -30,7 +30,7 @@ pub fn array_type(input: &str) -> ParseResult<UnderlyingType> {
         instantiable_type,
     ))
     .map(
-        |(_set, bound, _of, optional, unique, base)| UnderlyingType::Array {
+        |(_set, bound, _of, optional, unique, base)| ParameterType::Array {
             bound: Some(bound), // Maybe None for general_array_type
             unique: unique.is_some(),
             optional: optional.is_some(),
@@ -41,9 +41,9 @@ pub fn array_type(input: &str) -> ParseResult<UnderlyingType> {
 }
 
 /// 180 bag_type = BAG \[ [bound_spec] \] OF [instantiable_type] .
-pub fn bag_type(input: &str) -> ParseResult<UnderlyingType> {
+pub fn bag_type(input: &str) -> ParseResult<ParameterType> {
     tuple((tag("BAG"), opt(bound_spec), tag("OF"), instantiable_type))
-        .map(|(_set, bound, _of, base)| UnderlyingType::Bag {
+        .map(|(_set, bound, _of, base)| ParameterType::Bag {
             bound,
             base: Box::new(base),
         })
@@ -51,7 +51,7 @@ pub fn bag_type(input: &str) -> ParseResult<UnderlyingType> {
 }
 
 /// 250 list_type = LIST \[ [bound_spec] \] OF \[ UNIQUE \] [instantiable_type] .
-pub fn list_type(input: &str) -> ParseResult<UnderlyingType> {
+pub fn list_type(input: &str) -> ParseResult<ParameterType> {
     tuple((
         tag("LIST"),
         opt(bound_spec),
@@ -59,7 +59,7 @@ pub fn list_type(input: &str) -> ParseResult<UnderlyingType> {
         opt(tag("UNIQUE")),
         instantiable_type,
     ))
-    .map(|(_set, bound, _of, unique, base)| UnderlyingType::List {
+    .map(|(_set, bound, _of, unique, base)| ParameterType::List {
         bound,
         unique: unique.is_some(),
         base: Box::new(base),
@@ -68,9 +68,9 @@ pub fn list_type(input: &str) -> ParseResult<UnderlyingType> {
 }
 
 /// 303 set_type = SET \[ [bound_spec] \] OF [instantiable_type] .
-pub fn set_type(input: &str) -> ParseResult<UnderlyingType> {
+pub fn set_type(input: &str) -> ParseResult<ParameterType> {
     tuple((tag("SET"), opt(bound_spec), tag("OF"), instantiable_type))
-        .map(|(_set, bound, _of, base)| UnderlyingType::Set {
+        .map(|(_set, bound, _of, base)| ParameterType::Set {
             bound,
             base: Box::new(base),
         })
@@ -95,10 +95,10 @@ pub fn bound_spec(input: &str) -> ParseResult<Bound> {
 }
 
 /// 240 instantiable_type = [concrete_types] | [entity_ref] .
-pub fn instantiable_type(input: &str) -> ParseResult<UnderlyingType> {
+pub fn instantiable_type(input: &str) -> ParseResult<ParameterType> {
     alt((
         concrete_types,
-        entity_ref.map(|r| UnderlyingType::Reference(r)),
+        entity_ref.map(|r| ParameterType::Named(r)),
     ))
     .parse(input)
 }

--- a/espr/src/parser/types/enumeration.rs
+++ b/espr/src/parser/types/enumeration.rs
@@ -9,7 +9,7 @@ pub fn enumeration_items(input: &str) -> ParseResult<Vec<String>> {
 }
 
 /// 213 enumeration_type = \[ EXTENSIBLE \] ENUMERATION \[ ( OF [enumeration_items] ) | enumeration_extension \] .
-pub fn enumeration_type(input: &str) -> ParseResult<UnderlyingType> {
+pub fn enumeration_type(input: &str) -> ParseResult<ParameterType> {
     // FIXME enumeration_extension
     tuple((
         opt(tag("EXTENSIBLE")),
@@ -18,7 +18,7 @@ pub fn enumeration_type(input: &str) -> ParseResult<UnderlyingType> {
         enumeration_items,
     ))
     .map(
-        |(extensiblility, _start, _of, items)| UnderlyingType::Enumeration {
+        |(extensiblility, _start, _of, items)| ParameterType::Enumeration {
             extensibility: if extensiblility.is_some() {
                 Extensibility::Extensible
             } else {
@@ -43,7 +43,7 @@ mod tests {
         assert_eq!(residual, "");
         assert_eq!(
             e,
-            super::UnderlyingType::Enumeration {
+            super::ParameterType::Enumeration {
                 extensibility: super::Extensibility::None,
                 items: vec![
                     "up".to_string(),
@@ -64,7 +64,7 @@ mod tests {
         assert_eq!(residual, "");
         assert_eq!(
             e,
-            super::UnderlyingType::Enumeration {
+            super::ParameterType::Enumeration {
                 extensibility: super::Extensibility::Extensible,
                 items: vec![
                     "up".to_string(),

--- a/espr/src/parser/types/enumeration.rs
+++ b/espr/src/parser/types/enumeration.rs
@@ -9,7 +9,7 @@ pub fn enumeration_items(input: &str) -> ParseResult<Vec<String>> {
 }
 
 /// 213 enumeration_type = \[ EXTENSIBLE \] ENUMERATION \[ ( OF [enumeration_items] ) | enumeration_extension \] .
-pub fn enumeration_type(input: &str) -> ParseResult<ParameterType> {
+pub fn enumeration_type(input: &str) -> ParseResult<Type> {
     // FIXME enumeration_extension
     tuple((
         opt(tag("EXTENSIBLE")),
@@ -17,16 +17,14 @@ pub fn enumeration_type(input: &str) -> ParseResult<ParameterType> {
         tag("OF"),
         enumeration_items,
     ))
-    .map(
-        |(extensiblility, _start, _of, items)| ParameterType::Enumeration {
-            extensibility: if extensiblility.is_some() {
-                Extensibility::Extensible
-            } else {
-                Extensibility::None
-            },
-            items,
+    .map(|(extensiblility, _start, _of, items)| Type::Enumeration {
+        extensibility: if extensiblility.is_some() {
+            Extensibility::Extensible
+        } else {
+            Extensibility::None
         },
-    )
+        items,
+    })
     .parse(input)
 }
 
@@ -43,7 +41,7 @@ mod tests {
         assert_eq!(residual, "");
         assert_eq!(
             e,
-            super::ParameterType::Enumeration {
+            super::Type::Enumeration {
                 extensibility: super::Extensibility::None,
                 items: vec![
                     "up".to_string(),
@@ -64,7 +62,7 @@ mod tests {
         assert_eq!(residual, "");
         assert_eq!(
             e,
-            super::ParameterType::Enumeration {
+            super::Type::Enumeration {
                 extensibility: super::Extensibility::Extensible,
                 items: vec![
                     "up".to_string(),

--- a/espr/src/parser/types/generalized.rs
+++ b/espr/src/parser/types/generalized.rs
@@ -10,17 +10,17 @@ pub fn named_types(input: &str) -> ParseResult<String> {
 }
 
 /// 266 parameter_type = [generalized_types] | [named_types] | [simple_types] .
-pub fn parameter_type(input: &str) -> ParseResult<ParameterType> {
+pub fn parameter_type(input: &str) -> ParseResult<Type> {
     alt((
         generalized_types,
-        named_types.map(ParameterType::Named),
-        simple_types.map(ParameterType::Simple),
+        named_types.map(Type::Named),
+        simple_types.map(Type::Simple),
     ))
     .parse(input)
 }
 
 /// 223 generalized_types = [aggregate_type] | [general_aggregation_types] | [generic_entity_type] | [generic_type] .
-pub fn generalized_types(input: &str) -> ParseResult<ParameterType> {
+pub fn generalized_types(input: &str) -> ParseResult<Type> {
     alt((
         aggregate_type,
         general_aggregation_types,
@@ -31,33 +31,31 @@ pub fn generalized_types(input: &str) -> ParseResult<ParameterType> {
 }
 
 /// 171 aggregate_type = AGGREGATE \[ `:` [type_label] \] OF [parameter_type] .
-pub fn aggregate_type(input: &str) -> ParseResult<ParameterType> {
+pub fn aggregate_type(input: &str) -> ParseResult<Type> {
     tuple((
         tag("AGGREGATE"),
         opt(tuple((char(':'), type_label))),
         tag("OF"),
         parameter_type,
     ))
-    .map(
-        |(_aggregate, opt_type_label, _of, base)| ParameterType::Aggregate {
-            base: Box::new(base),
-            label: opt_type_label.map(|(_colon, label)| label),
-        },
-    )
+    .map(|(_aggregate, opt_type_label, _of, base)| Type::Aggregate {
+        base: Box::new(base),
+        label: opt_type_label.map(|(_colon, label)| label),
+    })
     .parse(input)
 }
 
 /// 230 generic_entity_type = GENERIC_ENTITY \[ `:` [type_label] \] .
-pub fn generic_entity_type(input: &str) -> ParseResult<ParameterType> {
+pub fn generic_entity_type(input: &str) -> ParseResult<Type> {
     tuple((tag("GENERIC_ENTITY"), opt(tuple((char(':'), type_label)))))
-        .map(|(_generic, opt)| ParameterType::GenericEntity(opt.map(|(_colon, label)| label)))
+        .map(|(_generic, opt)| Type::GenericEntity(opt.map(|(_colon, label)| label)))
         .parse(input)
 }
 
 /// 231 generic_type = GENERIC \[ `:` [type_label] \] .
-pub fn generic_type(input: &str) -> ParseResult<ParameterType> {
+pub fn generic_type(input: &str) -> ParseResult<Type> {
     tuple((tag("GENERIC"), opt(tuple((char(':'), type_label)))))
-        .map(|(_generic, opt)| ParameterType::Generic(opt.map(|(_colon, label)| label)))
+        .map(|(_generic, opt)| Type::Generic(opt.map(|(_colon, label)| label)))
         .parse(input)
 }
 
@@ -67,7 +65,7 @@ pub fn type_label(input: &str) -> ParseResult<String> {
 }
 
 /// 224 general_aggregation_types = [general_array_type] | [general_bag_type] | [general_list_type] | [general_set_type] .
-pub fn general_aggregation_types(input: &str) -> ParseResult<ParameterType> {
+pub fn general_aggregation_types(input: &str) -> ParseResult<Type> {
     alt((
         general_array_type,
         general_bag_type,
@@ -78,7 +76,7 @@ pub fn general_aggregation_types(input: &str) -> ParseResult<ParameterType> {
 }
 
 /// 225 general_array_type = ARRAY \[ [bound_spec] \] OF \[ OPTIONAL \] \[ UNIQUE \] [parameter_type] .
-pub fn general_array_type(input: &str) -> ParseResult<ParameterType> {
+pub fn general_array_type(input: &str) -> ParseResult<Type> {
     tuple((
         tag("ARRAY"),
         opt(bound_spec),
@@ -87,21 +85,19 @@ pub fn general_array_type(input: &str) -> ParseResult<ParameterType> {
         opt(tag("UNIQUE")),
         parameter_type,
     ))
-    .map(
-        |(_bag, bound, _of, optional, unique, base)| ParameterType::Array {
-            base: Box::new(base),
-            bound,
-            unique: unique.is_some(),
-            optional: optional.is_some(),
-        },
-    )
+    .map(|(_bag, bound, _of, optional, unique, base)| Type::Array {
+        base: Box::new(base),
+        bound,
+        unique: unique.is_some(),
+        optional: optional.is_some(),
+    })
     .parse(input)
 }
 
 /// 226 general_bag_type = BAG \[ [bound_spec] \] OF [parameter_type] .
-pub fn general_bag_type(input: &str) -> ParseResult<ParameterType> {
+pub fn general_bag_type(input: &str) -> ParseResult<Type> {
     tuple((tag("BAG"), opt(bound_spec), tag("OF"), parameter_type))
-        .map(|(_bag, bound, _of, base)| ParameterType::Bag {
+        .map(|(_bag, bound, _of, base)| Type::Bag {
             base: Box::new(base),
             bound,
         })
@@ -109,7 +105,7 @@ pub fn general_bag_type(input: &str) -> ParseResult<ParameterType> {
 }
 
 /// 227 general_list_type = LIST \[ [bound_spec] \] OF \[ UNIQUE \] [parameter_type] .
-pub fn general_list_type(input: &str) -> ParseResult<ParameterType> {
+pub fn general_list_type(input: &str) -> ParseResult<Type> {
     tuple((
         tag("LIST"),
         opt(bound_spec),
@@ -117,7 +113,7 @@ pub fn general_list_type(input: &str) -> ParseResult<ParameterType> {
         opt(tag("UNIQUE")),
         parameter_type,
     ))
-    .map(|(_list, bound, _of, unique, base)| ParameterType::List {
+    .map(|(_list, bound, _of, unique, base)| Type::List {
         base: Box::new(base),
         unique: unique.is_some(),
         bound,
@@ -126,9 +122,9 @@ pub fn general_list_type(input: &str) -> ParseResult<ParameterType> {
 }
 
 /// 229 general_set_type = SET \[ [bound_spec] \] OF [parameter_type] .
-pub fn general_set_type(input: &str) -> ParseResult<ParameterType> {
+pub fn general_set_type(input: &str) -> ParseResult<Type> {
     tuple((tag("SET"), opt(bound_spec), tag("OF"), parameter_type))
-        .map(|(_set, bound, _of, base)| ParameterType::Set {
+        .map(|(_set, bound, _of, base)| Type::Set {
             base: Box::new(base),
             bound,
         })
@@ -146,10 +142,7 @@ mod tests {
         let (res, (set, _remarks)) = super::parameter_type("STRING").finish().unwrap();
         dbg!(&set);
         assert_eq!(res, "");
-        assert_eq!(
-            set,
-            ParameterType::Simple(SimpleType::String_ { width_spec: None }),
-        )
+        assert_eq!(set, Type::Simple(SimpleType::String_ { width_spec: None }),)
     }
 
     #[test]
@@ -157,7 +150,7 @@ mod tests {
         let (res, (set, _remarks)) = super::parameter_type("vim").finish().unwrap();
         dbg!(&set);
         assert_eq!(res, "");
-        assert_eq!(set, ParameterType::Named("vim".to_string()),)
+        assert_eq!(set, Type::Named("vim".to_string()),)
     }
 
     #[test]
@@ -169,8 +162,8 @@ mod tests {
         assert_eq!(res, "");
         assert_eq!(
             set,
-            ParameterType::Set {
-                base: Box::new(ParameterType::Named("curve".to_string())),
+            Type::Set {
+                base: Box::new(Type::Named("curve".to_string())),
                 bound: Some(Bound {
                     upper: Expression::indeterminate(),
                     lower: Expression::real(1.0),

--- a/espr/src/parser/types/mod.rs
+++ b/espr/src/parser/types/mod.rs
@@ -14,12 +14,12 @@ use super::{combinator::*, entity::*, identifier::*};
 use crate::ast::*;
 
 /// 198 constructed_types = [enumeration_type] | [select_type] .
-pub fn constructed_types(input: &str) -> ParseResult<ParameterType> {
+pub fn constructed_types(input: &str) -> ParseResult<Type> {
     alt((enumeration_type, select_type)).parse(input)
 }
 
 /// 332 underlying_type = [concrete_types] | [constructed_types] .
-pub fn underlying_type(input: &str) -> ParseResult<ParameterType> {
+pub fn underlying_type(input: &str) -> ParseResult<Type> {
     alt((concrete_types, constructed_types)).parse(input)
 }
 
@@ -70,7 +70,7 @@ mod tests {
             ty,
             super::TypeDecl {
                 type_id: "my_type".to_string(),
-                underlying_type: super::ParameterType::Simple(super::SimpleType::String_ {
+                underlying_type: super::Type::Simple(super::SimpleType::String_ {
                     width_spec: None
                 }),
                 where_clause: None,

--- a/espr/src/parser/types/mod.rs
+++ b/espr/src/parser/types/mod.rs
@@ -14,12 +14,12 @@ use super::{combinator::*, entity::*, identifier::*};
 use crate::ast::*;
 
 /// 198 constructed_types = [enumeration_type] | [select_type] .
-pub fn constructed_types(input: &str) -> ParseResult<UnderlyingType> {
+pub fn constructed_types(input: &str) -> ParseResult<ParameterType> {
     alt((enumeration_type, select_type)).parse(input)
 }
 
 /// 332 underlying_type = [concrete_types] | [constructed_types] .
-pub fn underlying_type(input: &str) -> ParseResult<UnderlyingType> {
+pub fn underlying_type(input: &str) -> ParseResult<ParameterType> {
     alt((concrete_types, constructed_types)).parse(input)
 }
 
@@ -70,7 +70,7 @@ mod tests {
             ty,
             super::TypeDecl {
                 type_id: "my_type".to_string(),
-                underlying_type: super::UnderlyingType::Simple(super::SimpleType::String_ {
+                underlying_type: super::ParameterType::Simple(super::SimpleType::String_ {
                     width_spec: None
                 }),
                 where_clause: None,

--- a/espr/src/parser/types/select.rs
+++ b/espr/src/parser/types/select.rs
@@ -17,7 +17,7 @@ pub fn select_extension(input: &str) -> ParseResult<(String, Vec<String>)> {
 }
 
 /// 302 select_type = \[ EXTENSIBLE \[ GENERIC_ENTITY \] \] SELECT \[ [select_list] | [select_extension] \] .
-pub fn select_type(input: &str) -> ParseResult<ParameterType> {
+pub fn select_type(input: &str) -> ParseResult<Type> {
     // FIXME support select_extension
 
     // `GENERIC_ENTITY` only appears in `select_type` declaration.
@@ -40,12 +40,12 @@ pub fn select_type(input: &str) -> ParseResult<ParameterType> {
     ))
     .map(|(opt, _select, types)| {
         if let Some((extensibility, _spaces)) = opt {
-            ParameterType::Select {
+            Type::Select {
                 extensibility,
                 types,
             }
         } else {
-            ParameterType::Select {
+            Type::Select {
                 extensibility: Extensibility::None,
                 types,
             }
@@ -63,7 +63,7 @@ mod tests {
     fn select() {
         let (res, (s, _remarks)) = super::select_type("SELECT (a, b)").finish().unwrap();
         assert_eq!(res, "");
-        if let ParameterType::Select {
+        if let Type::Select {
             extensibility,
             types,
         } = s

--- a/espr/src/parser/types/select.rs
+++ b/espr/src/parser/types/select.rs
@@ -17,7 +17,7 @@ pub fn select_extension(input: &str) -> ParseResult<(String, Vec<String>)> {
 }
 
 /// 302 select_type = \[ EXTENSIBLE \[ GENERIC_ENTITY \] \] SELECT \[ [select_list] | [select_extension] \] .
-pub fn select_type(input: &str) -> ParseResult<UnderlyingType> {
+pub fn select_type(input: &str) -> ParseResult<ParameterType> {
     // FIXME support select_extension
 
     // `GENERIC_ENTITY` only appears in `select_type` declaration.
@@ -40,12 +40,12 @@ pub fn select_type(input: &str) -> ParseResult<UnderlyingType> {
     ))
     .map(|(opt, _select, types)| {
         if let Some((extensibility, _spaces)) = opt {
-            UnderlyingType::Select {
+            ParameterType::Select {
                 extensibility,
                 types,
             }
         } else {
-            UnderlyingType::Select {
+            ParameterType::Select {
                 extensibility: Extensibility::None,
                 types,
             }
@@ -63,7 +63,7 @@ mod tests {
     fn select() {
         let (res, (s, _remarks)) = super::select_type("SELECT (a, b)").finish().unwrap();
         assert_eq!(res, "");
-        if let UnderlyingType::Select {
+        if let ParameterType::Select {
             extensibility,
             types,
         } = s

--- a/espr/src/semantics/namespace.rs
+++ b/espr/src/semantics/namespace.rs
@@ -64,16 +64,16 @@ impl Namespace {
             let mut enumeration_types = Vec::new();
             let mut select_types = Vec::new();
             for ty in &schema.types {
-                use ast::UnderlyingType;
+                use ast::ParameterType;
                 match &ty.underlying_type {
-                    UnderlyingType::Simple(..) => simple_types.push(ty.type_id.clone()),
-                    UnderlyingType::Reference(underlying_type) => {
+                    ParameterType::Simple(..) => simple_types.push(ty.type_id.clone()),
+                    ParameterType::Named(underlying_type) => {
                         rename_types.push((ty.type_id.clone(), underlying_type.clone()))
                     }
-                    UnderlyingType::Enumeration { .. } => {
+                    ParameterType::Enumeration { .. } => {
                         enumeration_types.push(ty.type_id.clone())
                     }
-                    UnderlyingType::Select { .. } => select_types.push(ty.type_id.clone()),
+                    ParameterType::Select { .. } => select_types.push(ty.type_id.clone()),
                     _ => unimplemented!(),
                 }
             }

--- a/espr/src/semantics/namespace.rs
+++ b/espr/src/semantics/namespace.rs
@@ -64,16 +64,14 @@ impl Namespace {
             let mut enumeration_types = Vec::new();
             let mut select_types = Vec::new();
             for ty in &schema.types {
-                use ast::ParameterType;
+                use ast::Type;
                 match &ty.underlying_type {
-                    ParameterType::Simple(..) => simple_types.push(ty.type_id.clone()),
-                    ParameterType::Named(underlying_type) => {
+                    Type::Simple(..) => simple_types.push(ty.type_id.clone()),
+                    Type::Named(underlying_type) => {
                         rename_types.push((ty.type_id.clone(), underlying_type.clone()))
                     }
-                    ParameterType::Enumeration { .. } => {
-                        enumeration_types.push(ty.type_id.clone())
-                    }
-                    ParameterType::Select { .. } => select_types.push(ty.type_id.clone()),
+                    Type::Enumeration { .. } => enumeration_types.push(ty.type_id.clone()),
+                    Type::Select { .. } => select_types.push(ty.type_id.clone()),
                     _ => unimplemented!(),
                 }
             }

--- a/espr/src/semantics/type_decl.rs
+++ b/espr/src/semantics/type_decl.rs
@@ -49,25 +49,25 @@ impl Legalize for TypeDecl {
         scope: &Scope,
         type_decl: &Self::Input,
     ) -> Result<Self, SemanticError> {
-        use ast::ParameterType;
+        use ast::Type;
         let id = type_decl.type_id.clone();
         Ok(match &type_decl.underlying_type {
-            ParameterType::Simple(ty) => TypeDecl::Simple(Simple {
+            Type::Simple(ty) => TypeDecl::Simple(Simple {
                 id,
                 ty: SimpleType(*ty),
             }),
-            ParameterType::Named(name) => {
+            Type::Named(name) => {
                 let ty = ns.lookup_type(scope, name)?;
                 TypeDecl::Rename(Rename { id, ty })
             }
-            ParameterType::Enumeration {
+            Type::Enumeration {
                 items,
                 extensibility: _,
             } => TypeDecl::Enumeration(Enumeration {
                 id,
                 items: items.clone(),
             }),
-            ParameterType::Select {
+            Type::Select {
                 types,
                 extensibility: _,
             } => {

--- a/espr/src/semantics/type_decl.rs
+++ b/espr/src/semantics/type_decl.rs
@@ -49,25 +49,25 @@ impl Legalize for TypeDecl {
         scope: &Scope,
         type_decl: &Self::Input,
     ) -> Result<Self, SemanticError> {
-        use ast::UnderlyingType;
+        use ast::ParameterType;
         let id = type_decl.type_id.clone();
         Ok(match &type_decl.underlying_type {
-            UnderlyingType::Simple(ty) => TypeDecl::Simple(Simple {
+            ParameterType::Simple(ty) => TypeDecl::Simple(Simple {
                 id,
                 ty: SimpleType(*ty),
             }),
-            UnderlyingType::Reference(name) => {
+            ParameterType::Named(name) => {
                 let ty = ns.lookup_type(scope, name)?;
                 TypeDecl::Rename(Rename { id, ty })
             }
-            UnderlyingType::Enumeration {
+            ParameterType::Enumeration {
                 items,
                 extensibility: _,
             } => TypeDecl::Enumeration(Enumeration {
                 id,
                 items: items.clone(),
             }),
-            UnderlyingType::Select {
+            ParameterType::Select {
                 types,
                 extensibility: _,
             } => {

--- a/espr/src/semantics/type_ref.rs
+++ b/espr/src/semantics/type_ref.rs
@@ -83,15 +83,15 @@ impl TypeRef {
 }
 
 impl Legalize for TypeRef {
-    type Input = ast::ParameterType;
+    type Input = ast::Type;
 
     fn legalize(
         ns: &Namespace,
         ss: &SubSuperGraph,
         scope: &Scope,
-        ty: &ast::ParameterType,
+        ty: &ast::Type,
     ) -> Result<Self, SemanticError> {
-        use ast::ParameterType::*;
+        use ast::Type::*;
         Ok(match ty {
             Simple(ty) => Self::SimpleType(SimpleType(*ty)),
             Named(name) => ns.lookup_type(scope, name)?,


### PR DESCRIPTION
They are almost same except for some rare cases. These cases should be handled in later phase to keep AST simpler.