### PR TITLE
Placeholder deserialize with new data model

### DIFF
--- a/ruststep-derive/src/lib.rs
+++ b/ruststep-derive/src/lib.rs
@@ -172,17 +172,34 @@ fn as_holder_path(input: syn::Type) -> syn::Type {
 fn ruststep_crate() -> syn::Path {
     let path = crate_name("ruststep").unwrap();
     match path {
-        FoundCrate::Itself => {
-            let mut segments = syn::punctuated::Punctuated::new();
-            segments.push(syn::PathSegment {
-                ident: syn::Ident::new("crate", Span::call_site()),
-                arguments: syn::PathArguments::None,
-            });
-            syn::Path {
-                leading_colon: None,
-                segments,
+        FoundCrate::Itself => match std::env::var("CARGO_TARGET_TMPDIR") {
+            Ok(_) => {
+                // For tests and benches in ruststep crate
+                //
+                // https://doc.rust-lang.org/cargo/reference/environment-variables.html
+                // > CARGO_TARGET_TMPDIR — Only set when building integration test or benchmark code.
+                let mut segments = syn::punctuated::Punctuated::new();
+                segments.push(syn::PathSegment {
+                    ident: syn::Ident::new("ruststep", Span::call_site()),
+                    arguments: syn::PathArguments::None,
+                });
+                syn::Path {
+                    leading_colon: Some(syn::token::Colon2::default()),
+                    segments,
+                }
             }
-        }
+            Err(_) => {
+                let mut segments = syn::punctuated::Punctuated::new();
+                segments.push(syn::PathSegment {
+                    ident: syn::Ident::new("crate", Span::call_site()),
+                    arguments: syn::PathArguments::None,
+                });
+                syn::Path {
+                    leading_colon: None,
+                    segments,
+                }
+            }
+        },
         FoundCrate::Name(name) => {
             let mut segments = syn::punctuated::Punctuated::new();
             segments.push(syn::PathSegment {

--- a/ruststep/src/place_holder.rs
+++ b/ruststep/src/place_holder.rs
@@ -34,7 +34,7 @@ impl<T: Holder> PlaceHolder<T> {
     }
 }
 
-impl<'de, T: Holder + Deserialize<'de>> Deserialize<'de> for PlaceHolder<T> {
+impl<'de, T: Holder + WithVisitor + Deserialize<'de>> Deserialize<'de> for PlaceHolder<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -59,7 +59,7 @@ impl<T> Default for PlaceHolderVisitor<T> {
     }
 }
 
-impl<'de, T: Deserialize<'de> + Holder> de::Visitor<'de> for PlaceHolderVisitor<T> {
+impl<'de, T: Deserialize<'de> + Holder + WithVisitor> de::Visitor<'de> for PlaceHolderVisitor<T> {
     type Value = PlaceHolder<T>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/ruststep/src/tables.rs
+++ b/ruststep/src/tables.rs
@@ -1,14 +1,17 @@
 //! Traits for espr-generated structures
 
+use serde::de;
 use std::collections::HashMap;
 
 /// Trait for resolving a reference through entity id
 pub trait Holder: Clone + 'static {
     type Owned;
     type Table;
+    type Visitor: for<'de> de::Visitor<'de, Value = Self>;
     fn into_owned(self, table: &Self::Table) -> Result<Self::Owned, crate::error::Error>;
     fn name() -> &'static str;
     fn attr_len() -> usize;
+    fn visitor_new() -> Self::Visitor;
 }
 
 /// Trait for tables which pulls an entity (`T`) from an entity id (`u64`)

--- a/ruststep/src/tables.rs
+++ b/ruststep/src/tables.rs
@@ -7,10 +7,13 @@ use std::collections::HashMap;
 pub trait Holder: Clone + 'static {
     type Owned;
     type Table;
-    type Visitor: for<'de> de::Visitor<'de, Value = Self>;
     fn into_owned(self, table: &Self::Table) -> Result<Self::Owned, crate::error::Error>;
     fn name() -> &'static str;
     fn attr_len() -> usize;
+}
+
+pub trait WithVisitor {
+    type Visitor: for<'de> de::Visitor<'de, Value = Self>;
     fn visitor_new() -> Self::Visitor;
 }
 

--- a/ruststep/tests/holder.rs
+++ b/ruststep/tests/holder.rs
@@ -1,0 +1,13 @@
+use ruststep_derive::as_holder;
+use std::collections::HashMap;
+
+pub struct Table {
+    a: HashMap<u64, as_holder!(A)>,
+}
+
+#[derive(Debug, Clone, ruststep_derive::Holder)]
+#[holder(table = Table, field = a)]
+pub struct A {
+    x: f64,
+    y: f64,
+}

--- a/ruststep/tests/holder.rs
+++ b/ruststep/tests/holder.rs
@@ -1,13 +1,86 @@
-use ruststep_derive::as_holder;
-use std::collections::HashMap;
+use ruststep::{ast::Record, parser::exchange, place_holder::PlaceHolder};
 
-pub struct Table {
-    a: HashMap<u64, as_holder!(A)>,
-}
+use nom::Finish;
+use serde::{de, Deserialize};
 
-#[derive(Debug, Clone, ruststep_derive::Holder)]
-#[holder(table = Table, field = a)]
-pub struct A {
+#[derive(Debug, Clone, PartialEq)]
+struct A {
     x: f64,
     y: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct AHolder {
+    x: f64,
+    y: f64,
+}
+
+impl<'de> de::Deserialize<'de> for AHolder {
+    fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_tuple_struct("A", 2, AHolderVisitor {})
+    }
+}
+
+struct AHolderVisitor;
+
+impl<'de> ::serde::de::Visitor<'de> for AHolderVisitor {
+    type Value = AHolder;
+    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(formatter, "A")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> ::std::result::Result<Self::Value, A::Error>
+    where
+        A: ::serde::de::SeqAccess<'de>,
+    {
+        if let Some(size) = seq.size_hint() {
+            if size != 2 {
+                use ::serde::de::Error;
+                return Err(A::Error::invalid_length(size, &self));
+            }
+        }
+        let x = seq.next_element()?.unwrap();
+        let y = seq.next_element()?.unwrap();
+        Ok(AHolder { x, y })
+    }
+
+    // Entry point for Record or Parameter::Typed
+    fn visit_map<A>(self, mut map: A) -> ::std::result::Result<Self::Value, A::Error>
+    where
+        A: ::serde::de::MapAccess<'de>,
+    {
+        let key: String = map
+            .next_key()?
+            .expect("Empty map cannot be accepted as ruststep Holder"); // this must be a bug, not runtime error
+        if key != "A" {
+            use ::serde::de::{Error, Unexpected};
+            return Err(A::Error::invalid_value(Unexpected::Other(&key), &self));
+        }
+        let value = map.next_value()?; // send to Self::visit_seq
+        Ok(value)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct B {
+    z: f64,
+    a: A,
+}
+
+#[derive(Debug, Clone)]
+struct BHolder {
+    z: f64,
+    a: PlaceHolder<AHolder>,
+}
+
+#[test]
+fn deserialize_a_holder_from_record() {
+    let (residual, p): (_, Record) = exchange::simple_record("A(1.0, 2.0)").finish().unwrap();
+    assert_eq!(residual, "");
+    dbg!(&p);
+    let a: AHolder = Deserialize::deserialize(&p).unwrap();
+    assert_eq!(a, AHolder { x: 1.0, y: 2.0 });
 }

--- a/ruststep/tests/holder.rs
+++ b/ruststep/tests/holder.rs
@@ -1,9 +1,25 @@
+// Test for deserializing Holder structs
+//
+// This tests does not use proc-macro in ruststep-derive in order not to depend on them.
+
 use ruststep::{ast::*, error::*, parser::exchange, place_holder::PlaceHolder, tables::*};
 
 use nom::Finish;
 use serde::{de, Deserialize};
+use std::collections::HashMap;
 
-struct Table;
+struct Table {
+    a: HashMap<u64, AHolder>,
+}
+
+impl EntityTable<AHolder> for Table {
+    fn get_owned(&self, entity_id: u64) -> Result<A> {
+        get_owned(self, &self.a, entity_id)
+    }
+    fn owned_iter<'table>(&'table self) -> Box<dyn Iterator<Item = Result<A>> + 'table> {
+        owned_iter(self, &self.a)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 struct A {
@@ -88,41 +104,171 @@ impl WithVisitor for AHolder {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct B {
     z: f64,
     a: A,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct BHolder {
     z: f64,
     a: PlaceHolder<AHolder>,
 }
 
+impl<'de> de::Deserialize<'de> for BHolder {
+    fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_tuple_struct("A", 2, BHolderVisitor {})
+    }
+}
+
+struct BHolderVisitor;
+
+impl<'de> ::serde::de::Visitor<'de> for BHolderVisitor {
+    type Value = BHolder;
+    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(formatter, "A")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> ::std::result::Result<Self::Value, A::Error>
+    where
+        A: ::serde::de::SeqAccess<'de>,
+    {
+        if let Some(size) = seq.size_hint() {
+            if size != 2 {
+                use ::serde::de::Error;
+                return Err(A::Error::invalid_length(size, &self));
+            }
+        }
+        let z = seq.next_element()?.unwrap();
+        let a = seq.next_element()?.unwrap();
+        Ok(BHolder { z, a })
+    }
+
+    // Entry point for Record or Parameter::Typed
+    fn visit_map<A>(self, mut map: A) -> ::std::result::Result<Self::Value, A::Error>
+    where
+        A: ::serde::de::MapAccess<'de>,
+    {
+        let key: String = map
+            .next_key()?
+            .expect("Empty map cannot be accepted as ruststep Holder"); // this must be a bug, not runtime error
+        if key != "B" {
+            use ::serde::de::{Error, Unexpected};
+            return Err(A::Error::invalid_value(Unexpected::Other(&key), &self));
+        }
+        let value = map.next_value()?; // send to Self::visit_seq
+        Ok(value)
+    }
+}
+
+impl Holder for BHolder {
+    type Owned = B;
+    type Table = Table;
+    fn into_owned(self, table: &Self::Table) -> Result<Self::Owned> {
+        let BHolder { z, a } = self;
+        Ok(B {
+            z,
+            a: a.into_owned(table)?,
+        })
+    }
+    fn name() -> &'static str {
+        "B"
+    }
+    fn attr_len() -> usize {
+        2
+    }
+}
+
+impl WithVisitor for BHolder {
+    type Visitor = BHolderVisitor;
+    fn visitor_new() -> Self::Visitor {
+        BHolderVisitor {}
+    }
+}
+
 #[test]
-fn deserialize_a_holder_from_record() {
+fn deserialize_a_holder() {
+    // from Record
     let (residual, p): (_, Record) = exchange::simple_record("A(1.0, 2.0)").finish().unwrap();
     assert_eq!(residual, "");
     dbg!(&p);
     let a: AHolder = Deserialize::deserialize(&p).unwrap();
     assert_eq!(a, AHolder { x: 1.0, y: 2.0 });
-}
 
-#[test]
-fn deserialize_a_holder_from_typed() {
+    // from Parameter::Typed
     let (residual, p): (_, Parameter) = exchange::parameter("A((1.0, 2.0))").finish().unwrap();
     assert_eq!(residual, "");
     dbg!(&p);
     let a: AHolder = Deserialize::deserialize(&p).unwrap();
     assert_eq!(a, AHolder { x: 1.0, y: 2.0 });
-}
 
-#[test]
-fn deserialize_a_place_holder_from_record() {
+    // Test for PlaceHolder<AHolder>
     let (residual, p): (_, Record) = exchange::simple_record("A(1.0, 2.0)").finish().unwrap();
     assert_eq!(residual, "");
     dbg!(&p);
     let a: PlaceHolder<AHolder> = Deserialize::deserialize(&p).unwrap();
     assert_eq!(a, PlaceHolder::Owned(AHolder { x: 1.0, y: 2.0 }));
+}
+
+#[test]
+fn deserialize_b_holder() {
+    // from Record
+    let (residual, p): (_, Record) = exchange::simple_record("B(1.0, A((2.0, 3.0)))")
+        .finish()
+        .unwrap();
+    assert_eq!(residual, "");
+    dbg!(&p);
+    let b: BHolder = Deserialize::deserialize(&p).unwrap();
+    assert_eq!(
+        b,
+        BHolder {
+            z: 1.0,
+            a: PlaceHolder::Owned(AHolder { x: 2.0, y: 3.0 })
+        }
+    );
+
+    // from Record with ref
+    let (residual, p): (_, Record) = exchange::simple_record("B(1.0, #2)").finish().unwrap();
+    assert_eq!(residual, "");
+    dbg!(&p);
+    let b: BHolder = Deserialize::deserialize(&p).unwrap();
+    assert_eq!(
+        b,
+        BHolder {
+            z: 1.0,
+            a: PlaceHolder::Ref(RValue::Entity(2))
+        }
+    );
+
+    // from Parameter::Typed
+    let (residual, p): (_, Parameter) = exchange::parameter("B((1.0, A((2.0, 3.0))))")
+        .finish()
+        .unwrap();
+    assert_eq!(residual, "");
+    dbg!(&p);
+    let b: BHolder = Deserialize::deserialize(&p).unwrap();
+    assert_eq!(
+        b,
+        BHolder {
+            z: 1.0,
+            a: PlaceHolder::Owned(AHolder { x: 2.0, y: 3.0 })
+        }
+    );
+
+    // from Parameter::Typed with Ref
+    let (residual, p): (_, Parameter) = exchange::parameter("B((1.0, #2))").finish().unwrap();
+    assert_eq!(residual, "");
+    dbg!(&p);
+    let b: BHolder = Deserialize::deserialize(&p).unwrap();
+    assert_eq!(
+        b,
+        BHolder {
+            z: 1.0,
+            a: PlaceHolder::Ref(RValue::Entity(2))
+        }
+    );
 }


### PR DESCRIPTION
Split from #70 about `PlaceHolder<T>` part

- Re-enable `impl Deserialize for PlaceHolder<T>` based on new data model by #94 
- Introduce `WithVisitor` to get `T`'s Visitor object while deserializing `PlaceHolder<T>`

TODO
-------
- [x] Add test