### PR TITLE
Test for #[derive(Holder)] for enums

### DIFF
--- a/ruststep-derive/Cargo.toml
+++ b/ruststep-derive/Cargo.toml
@@ -18,6 +18,7 @@ proc-macro-error = "1.0.4"
 [dev-dependencies]
 serde = "1.0.129"
 trybuild = "1.0.45"
+itertools = "0.10.1"
 
 [dev-dependencies.ruststep]
 path = "../ruststep"

--- a/ruststep-derive/src/entity.rs
+++ b/ruststep-derive/src/entity.rs
@@ -66,9 +66,7 @@ impl FieldEntries {
                         into_owned.push(quote! { #ident.into_owned(#table_arg)? });
                     }
                     FieldType::Optional(_) => {
-                        into_owned.push(
-                        quote! { #ident.map(|holder| holder.into_owned(#table_arg)).transpose()? },
-                    );
+                        into_owned.push(quote! { #ident.map(|holder| holder.into_owned(#table_arg)).transpose()? });
                     }
                     FieldType::List(_) => into_owned.push(quote! {
                         #ident
@@ -76,6 +74,7 @@ impl FieldEntries {
                             .map(|v| v.into_owned(#table_arg))
                             .collect::<Result<Vec<_>, _>>()?
                     }),
+                    FieldType::Boxed(_) => abort_call_site!("Unexpected Box<T>"),
                 }
                 holder_types.push(ft.as_holder().as_place_holder().into());
             } else {

--- a/ruststep-derive/src/field_type.rs
+++ b/ruststep-derive/src/field_type.rs
@@ -12,6 +12,8 @@ pub enum FieldType {
     Optional(Box<FieldType>),
     /// Like `Vec<T>`
     List(Box<FieldType>),
+    /// Like `Box<T>`
+    Boxed(Box<FieldType>),
 }
 
 impl FieldType {
@@ -42,6 +44,10 @@ impl FieldType {
                 let holder = ty.as_holder();
                 FieldType::List(Box::new(holder))
             }
+            FieldType::Boxed(ty) => {
+                let holder = ty.as_holder();
+                FieldType::Boxed(Box::new(holder))
+            }
         }
     }
 
@@ -59,6 +65,10 @@ impl FieldType {
             FieldType::List(ty) => {
                 let place_holder = ty.as_place_holder();
                 FieldType::List(Box::new(place_holder))
+            }
+            FieldType::Boxed(ty) => {
+                let place_holder = ty.as_place_holder();
+                FieldType::Boxed(Box::new(place_holder))
             }
         }
     }
@@ -87,6 +97,10 @@ impl Into<syn::Type> for FieldType {
             FieldType::List(ty) => {
                 let ty: syn::Type = (*ty).into();
                 syn::parse_quote! { Vec<#ty> }
+            }
+            FieldType::Boxed(ty) => {
+                let ty: syn::Type = (*ty).into();
+                syn::parse_quote! { Box<#ty> }
             }
         };
         syn::Type::Path(syn::TypePath { qself: None, path })
@@ -121,10 +135,11 @@ impl TryFrom<syn::Type> for FieldType {
                     if last_seg.ident == "Vec" {
                         return Ok(FieldType::List(ty));
                     }
-                    return Err(UnsupportedTypeError {});
-                } else {
-                    return Err(UnsupportedTypeError {});
+                    if last_seg.ident == "Box" {
+                        return Ok(FieldType::Boxed(ty));
+                    }
                 }
+                return Err(UnsupportedTypeError {});
             }
             _ => Err(UnsupportedTypeError {}),
         }

--- a/ruststep-derive/src/holder_attr.rs
+++ b/ruststep-derive/src/holder_attr.rs
@@ -5,6 +5,7 @@
 //! - `#[holder(table = {path::to::table::struct})]`
 //! - `#[holder(field = {field_ident})]`
 //! - `#[holder(use_place_holder)]`
+//! - `#[holder(generate_deserialize)]`
 //!
 
 #[derive(Debug, Clone, PartialEq)]
@@ -12,6 +13,7 @@ pub struct HolderAttr {
     pub table: Option<syn::Path>,
     pub field: Option<syn::Ident>,
     pub place_holder: bool,
+    pub generate_deserialize: bool,
 }
 
 impl HolderAttr {
@@ -19,6 +21,7 @@ impl HolderAttr {
         let mut table = None;
         let mut field = None;
         let mut place_holder = false;
+        let mut generate_deserialize = false;
 
         for attr in attrs {
             match attr.parse_args().unwrap() {
@@ -31,12 +34,16 @@ impl HolderAttr {
                 Attr::PlaceHolder => {
                     place_holder = true;
                 }
+                Attr::GenerateDeserialize => {
+                    generate_deserialize = true;
+                }
             }
         }
         HolderAttr {
             table,
             field,
             place_holder,
+            generate_deserialize,
         }
     }
 }
@@ -46,6 +53,7 @@ enum Attr {
     Table(syn::Path),
     Field(syn::Ident),
     PlaceHolder,
+    GenerateDeserialize,
 }
 
 impl syn::parse::Parse for Attr {
@@ -63,6 +71,7 @@ impl syn::parse::Parse for Attr {
                 Ok(Attr::Field(ident))
             }
             "use_place_holder" => Ok(Attr::PlaceHolder),
+            "generate_deserialize" => Ok(Attr::GenerateDeserialize),
             _ => Err(syn::parse::Error::new(
                 ident.span(),
                 "expected `table`, `field`, or `use_place_holder`",

--- a/ruststep-derive/src/lib.rs
+++ b/ruststep-derive/src/lib.rs
@@ -73,11 +73,11 @@ pub fn derive_holder_entry(input: TokenStream) -> TokenStream {
 }
 
 fn derive_holder(ast: &syn::DeriveInput) -> TokenStream2 {
-    let table_attr = HolderAttr::parse(&ast.attrs);
+    let attr = HolderAttr::parse(&ast.attrs);
     let ident = &ast.ident;
     match &ast.data {
-        syn::Data::Struct(st) => entity::derive_holder(ident, st, &table_attr),
-        syn::Data::Enum(e) => select::derive_holder(ident, e),
+        syn::Data::Struct(st) => entity::derive_holder(ident, st, &attr),
+        syn::Data::Enum(e) => select::derive_holder(ident, e, &attr),
         _ => abort_call_site!("Only struct is supprted currently"),
     }
 }

--- a/ruststep-derive/src/select.rs
+++ b/ruststep-derive/src/select.rs
@@ -226,21 +226,28 @@ fn decompose_box_ty(ty: &syn::Type) -> &syn::Type {
     unreachable!("Not Box<T>")
 }
 
-pub fn derive_holder(ident: &syn::Ident, e: &syn::DataEnum) -> TokenStream2 {
+pub fn derive_holder(ident: &syn::Ident, e: &syn::DataEnum, attr: &HolderAttr) -> TokenStream2 {
     let input = Input::parse(ident, e);
     let def_holder_tt = input.def_holder();
     let impl_holder_tt = input.impl_holder();
-    let impl_deserialize_tt = input.impl_deserialize();
-    let def_visitor_tt = input.def_visitor();
-    let impl_entity_table_tt = input.impl_entity_table();
 
-    quote! {
-        #def_holder_tt
-        #impl_holder_tt
-        #impl_deserialize_tt
-        #def_visitor_tt
-        #impl_entity_table_tt
-    } // quote!
+    if attr.generate_deserialize {
+        let impl_deserialize_tt = input.impl_deserialize();
+        let def_visitor_tt = input.def_visitor();
+        let impl_entity_table_tt = input.impl_entity_table();
+        quote! {
+            #def_holder_tt
+            #impl_holder_tt
+            #impl_deserialize_tt
+            #def_visitor_tt
+            #impl_entity_table_tt
+        } // quote!
+    } else {
+        quote! {
+            #def_holder_tt
+            #impl_holder_tt
+        } // quote!
+    }
 }
 
 pub fn derive_deserialize(_ident: &syn::Ident, _e: &syn::DataEnum) -> TokenStream2 {

--- a/ruststep-derive/src/select.rs
+++ b/ruststep-derive/src/select.rs
@@ -125,7 +125,6 @@ impl Input {
     fn def_visitor(&self) -> TokenStream2 {
         let Input {
             holder_ident,
-            holder_types,
             holder_visitor_ident,
             name,
             variants,
@@ -154,7 +153,7 @@ impl Input {
                     match key.as_str() {
                         #(
                         #variant_names => {
-                            let value: #holder_types = map.next_value()?;
+                            let value = map.next_value()?;
                             return Ok(#holder_ident::#variants(Box::new(value)));
                         }
                         )*

--- a/ruststep-derive/src/select.rs
+++ b/ruststep-derive/src/select.rs
@@ -11,7 +11,7 @@ struct Input {
     variants: Vec<syn::Ident>,
     variant_names: Vec<String>,
     holder_types: Vec<syn::Type>,
-    table_fields: Vec<syn::Ident>,
+    table_fields: Vec<Option<syn::Ident>>,
 }
 
 impl Input {
@@ -37,12 +37,12 @@ impl Input {
             })
             .flatten()
             .collect();
-        let table_fields: Vec<syn::Ident> = e
+        let table_fields: Vec<Option<syn::Ident>> = e
             .variants
             .iter()
             .map(|var| {
                 let attr = HolderAttr::parse(&var.attrs);
-                attr.field.expect("field attribute is lacking")
+                attr.field
             })
             .collect();
 
@@ -68,7 +68,7 @@ impl Input {
         quote! {
             #[derive(Clone, Debug, PartialEq)]
             enum #holder_ident {
-                #(#variants(Box<#holder_types>)),*
+                #(#variants(#holder_types)),*
             }
         } // quote!
     }

--- a/ruststep-derive/tests/cases/select.rs
+++ b/ruststep-derive/tests/cases/select.rs
@@ -23,11 +23,20 @@ pub struct B {
 
 #[derive(Debug, Clone, PartialEq, Holder)]
 #[holder(table = Table)]
-pub enum S {
+pub enum S1 {
     #[holder(field = a)]
     A(Box<A>),
     #[holder(field = b)]
     B(Box<B>),
+}
+
+#[derive(Debug, Clone, PartialEq, Holder)]
+#[holder(table = Table)]
+pub enum S2 {
+    #[holder(field = a)]
+    A(Box<A>),
+    // mix primitive type
+    P(f64),
 }
 
 fn main() {}

--- a/ruststep-derive/tests/cases/select.rs
+++ b/ruststep-derive/tests/cases/select.rs
@@ -25,8 +25,10 @@ pub struct B {
 #[holder(table = Table)]
 pub enum S1 {
     #[holder(field = a)]
+    #[holder(use_place_holder)]
     A(Box<A>),
     #[holder(field = b)]
+    #[holder(use_place_holder)]
     B(Box<B>),
 }
 
@@ -34,6 +36,7 @@ pub enum S1 {
 #[holder(table = Table)]
 pub enum S2 {
     #[holder(field = a)]
+    #[holder(use_place_holder)]
     A(Box<A>),
     // mix primitive type
     P(f64),

--- a/ruststep-derive/tests/cases/select.rs
+++ b/ruststep-derive/tests/cases/select.rs
@@ -25,9 +25,9 @@ pub struct B {
 #[holder(table = Table)]
 pub enum S {
     #[holder(field = a)]
-    A(A),
+    A(Box<A>),
     #[holder(field = b)]
-    B(B),
+    B(Box<B>),
 }
 
 fn main() {}

--- a/ruststep-derive/tests/cases/select.rs
+++ b/ruststep-derive/tests/cases/select.rs
@@ -1,0 +1,33 @@
+use ruststep_derive::{as_holder, Holder};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Table {
+    a: HashMap<u64, as_holder!(A)>,
+    b: HashMap<u64, as_holder!(B)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Holder)]
+#[holder(table = Table)]
+#[holder(field = a)]
+pub struct A {
+    pub x: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Holder)]
+#[holder(table = Table)]
+#[holder(field = b)]
+pub struct B {
+    pub y: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Holder)]
+#[holder(table = Table)]
+pub enum S {
+    #[holder(field = a)]
+    A(A),
+    #[holder(field = b)]
+    B(B),
+}
+
+fn main() {}

--- a/ruststep-derive/tests/try_build.rs
+++ b/ruststep-derive/tests/try_build.rs
@@ -4,4 +4,5 @@ fn try_build() {
     t.pass("tests/cases/use_place_holder.rs");
     t.pass("tests/cases/optional.rs");
     t.pass("tests/cases/vec.rs");
+    t.pass("tests/cases/select.rs");
 }

--- a/ruststep/tests/any_deserialize.rs
+++ b/ruststep/tests/any_deserialize.rs
@@ -1,5 +1,5 @@
 use nom::Finish;
-use ruststep::{ast::*, error::*, parser::exchange, place_holder::*, tables::*};
+use ruststep::{ast::*, parser::exchange, place_holder::*, tables::*};
 use ruststep_derive::as_holder;
 use serde::{de, Deserialize};
 use std::collections::HashMap;
@@ -232,6 +232,7 @@ impl WithVisitor for Sub2Holder {
 
 #[derive(Clone, Debug, PartialEq, ruststep_derive::Holder)]
 #[holder(table = Table)]
+#[holder(generate_deserialize)]
 enum BaseAny {
     #[holder(field = base)]
     Base(Box<Base>),

--- a/ruststep/tests/any_deserialize.rs
+++ b/ruststep/tests/any_deserialize.rs
@@ -235,10 +235,13 @@ impl WithVisitor for Sub2Holder {
 #[holder(generate_deserialize)]
 enum BaseAny {
     #[holder(field = base)]
+    #[holder(use_place_holder)]
     Base(Box<Base>),
     #[holder(field = sub1)]
+    #[holder(use_place_holder)]
     Sub1(Box<Sub1>),
     #[holder(field = sub2)]
+    #[holder(use_place_holder)]
     Sub2(Box<Sub2>),
 }
 


### PR DESCRIPTION
From #70 

- Add `#[holder(generate_deserialize)]` switch for disabling generation of `impl Deserialize`