### PR TITLE
Inline EXPRESS schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 ## Unreleased (will be 0.2.0)
 
 ### Added
+- espr_derive crate, `espr_derive::inline_express!` macro https://github.com/ricosjp/ruststep/pull/158
 - Expose `ruststep_derive::*` macros in `ruststep::` namespace https://github.com/ricosjp/ruststep/pull/159
 - Use rust-cache for faster CI https://github.com/ricosjp/ruststep/pull/156
 - Comprehensive tests for ruststep_derive https://github.com/ricosjp/ruststep/pull/147

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 - impl `FromStr` for `Record` and `DataSection` https://github.com/ricosjp/ruststep/pull/140
 
 ### Changed
+- Add flag to switch ruststep internal/external codegen in IR::to_token_stream https://github.com/ricosjp/ruststep/pull/158
 - Remove `ruststep_derive::as_holder_visitor!` https://github.com/ricosjp/ruststep/pull/147
 - Use Rust 2021 edition https://github.com/ricosjp/ruststep/pull/128
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "espr",
+  "espr-derive",
   "ruststep",
   "ruststep-derive",
 ]

--- a/espr-derive/Cargo.toml
+++ b/espr-derive/Cargo.toml
@@ -10,7 +10,7 @@ proc-macro = true
 quote = "1.0.9"
 proc-macro2 = "1.0.28"
 syn = { version = "1.0.75", features = ["full", "extra-traits"] }
-proc-macro-error = "1.0.4"
 
 [dependencies.espr]
+version = "0.1.0"
 path = "../espr"

--- a/espr-derive/Cargo.toml
+++ b/espr-derive/Cargo.toml
@@ -14,3 +14,8 @@ syn = { version = "1.0.75", features = ["full", "extra-traits"] }
 [dependencies.espr]
 version = "0.1.0"
 path = "../espr"
+
+[dev-dependencies]
+ruststep = { version = "0.1.0", path = "../ruststep" }
+ruststep-derive = { version = "0.1.0", path = "../ruststep-derive" }
+serde = "1.0"

--- a/espr-derive/Cargo.toml
+++ b/espr-derive/Cargo.toml
@@ -7,3 +7,10 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
+quote = "1.0.9"
+proc-macro2 = "1.0.28"
+syn = { version = "1.0.75", features = ["full", "extra-traits"] }
+proc-macro-error = "1.0.4"
+
+[dependencies.espr]
+path = "../espr"

--- a/espr-derive/Cargo.toml
+++ b/espr-derive/Cargo.toml
@@ -19,3 +19,4 @@ path = "../espr"
 ruststep = { version = "0.1.0", path = "../ruststep" }
 ruststep-derive = { version = "0.1.0", path = "../ruststep-derive" }
 serde = "1.0"
+derive-new = "0.5.9"

--- a/espr-derive/Cargo.toml
+++ b/espr-derive/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "espr-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]

--- a/espr-derive/src/lib.rs
+++ b/espr-derive/src/lib.rs
@@ -1,0 +1,10 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::{abort_call_site, proc_macro_error};
+use quote::quote;
+
+#[proc_macro_error]
+#[proc_macro]
+pub fn inline_express(input: TokenStream) -> TokenStream {
+    abort_call_site!("Not implemented")
+}

--- a/espr-derive/src/lib.rs
+++ b/espr-derive/src/lib.rs
@@ -1,7 +1,7 @@
+use espr::{ast::SyntaxTree, ir::IR};
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
-use proc_macro_error::{abort_call_site, proc_macro_error};
-use quote::quote;
+use proc_macro_error::proc_macro_error;
+use quote::ToTokens;
 
 /// Compile and expand results inline EXPRESS
 ///
@@ -20,5 +20,9 @@ use quote::quote;
 #[proc_macro_error]
 #[proc_macro]
 pub fn inline_express(input: TokenStream) -> TokenStream {
-    abort_call_site!("Not implemented")
+    let input: syn::LitStr =
+        syn::parse(input).expect("inline_express! argument must be string literal");
+    let st = SyntaxTree::parse(&input.value()).expect("Tokenize failed");
+    let ir = IR::from_syntax_tree(&st).expect("Failed in semantic analysis phase");
+    ir.to_token_stream().into()
 }

--- a/espr-derive/src/lib.rs
+++ b/espr-derive/src/lib.rs
@@ -2,7 +2,7 @@ use espr::{ast::SyntaxTree, ir::IR};
 use proc_macro::TokenStream;
 use quote::ToTokens;
 
-/// Compile and expand results inline EXPRESS
+/// Compile inline EXPRESS into Rust code, and expand it on the call site.
 ///
 /// Example
 /// --------
@@ -18,6 +18,10 @@ use quote::ToTokens;
 /// ```
 #[proc_macro]
 pub fn inline_express(input: TokenStream) -> TokenStream {
+    // FIXME Use proc-macro-error
+    //
+    // espr::Result does not match its requirement currently. We have to fix it.
+    //
     let input: syn::LitStr =
         syn::parse(input).expect("inline_express! argument must be string literal");
     let st = SyntaxTree::parse(&input.value()).expect("Tokenize failed");

--- a/espr-derive/src/lib.rs
+++ b/espr-derive/src/lib.rs
@@ -3,6 +3,20 @@ use proc_macro2::TokenStream as TokenStream2;
 use proc_macro_error::{abort_call_site, proc_macro_error};
 use quote::quote;
 
+/// Compile and expand results inline EXPRESS
+///
+/// Example
+/// --------
+///
+/// ```
+/// espr_derive::inline_express!(r#"
+/// SCHEMA explicit_draughting;
+///   ENTITY a;
+///     x: REAL;
+///   END_ENTITY;
+/// END_SCHEMA;
+/// "#);
+/// ```
 #[proc_macro_error]
 #[proc_macro]
 pub fn inline_express(input: TokenStream) -> TokenStream {

--- a/espr-derive/src/lib.rs
+++ b/espr-derive/src/lib.rs
@@ -1,6 +1,5 @@
-use espr::{ast::SyntaxTree, ir::IR};
+use espr::{ast::SyntaxTree, codegen::rust::*, ir::IR};
 use proc_macro::TokenStream;
-use quote::ToTokens;
 
 /// Compile inline EXPRESS into Rust code, and expand it on the call site.
 ///
@@ -26,5 +25,5 @@ pub fn inline_express(input: TokenStream) -> TokenStream {
         syn::parse(input).expect("inline_express! argument must be string literal");
     let st = SyntaxTree::parse(&input.value()).expect("Tokenize failed");
     let ir = IR::from_syntax_tree(&st).expect("Failed in semantic analysis phase");
-    ir.to_token_stream().into()
+    ir.to_token_stream(CratePrefix::External).into()
 }

--- a/espr-derive/src/lib.rs
+++ b/espr-derive/src/lib.rs
@@ -1,6 +1,5 @@
 use espr::{ast::SyntaxTree, ir::IR};
 use proc_macro::TokenStream;
-use proc_macro_error::proc_macro_error;
 use quote::ToTokens;
 
 /// Compile and expand results inline EXPRESS
@@ -17,7 +16,6 @@ use quote::ToTokens;
 /// END_SCHEMA;
 /// "#);
 /// ```
-#[proc_macro_error]
 #[proc_macro]
 pub fn inline_express(input: TokenStream) -> TokenStream {
     let input: syn::LitStr =

--- a/espr/src/bin/esprc.rs
+++ b/espr/src/bin/esprc.rs
@@ -1,7 +1,6 @@
 //! Executable for espr EXPRESS language compiler
 
-use espr::{ast::SyntaxTree, ir::IR};
-use quote::ToTokens;
+use espr::{ast::SyntaxTree, codegen::rust::*, ir::IR};
 use std::{fs, path::*};
 use structopt::StructOpt;
 
@@ -40,5 +39,8 @@ fn main() {
     }
 
     let ir = IR::from_syntax_tree(&st).expect("Failed in semantic analysis phase");
-    println!("#![allow(dead_code)]\n{}", ir.to_token_stream().to_string());
+    println!(
+        "#![allow(dead_code)]\n{}",
+        ir.to_token_stream(CratePrefix::Internal).to_string()
+    );
 }

--- a/espr/src/codegen/rust/entity.rs
+++ b/espr/src/codegen/rust/entity.rs
@@ -67,7 +67,7 @@ impl ToTokens for Entity {
         assert_eq!(attr_name.len(), use_place_holder.len());
 
         tokens.append_all(quote! {
-            #[derive(Debug, Clone, PartialEq, ::derive_new::new, ::ruststep_derive::Holder)]
+            #[derive(Debug, Clone, PartialEq, ::derive_new::new, Holder)]
             #[holder(table = Tables)]
             #[holder(field = #field_name)]
             #[holder(generate_deserialize)]
@@ -90,7 +90,7 @@ impl ToTokens for Entity {
                 .collect();
             let enum_name = format_ident!("{}Any", name);
             tokens.append_all(quote! {
-                #[derive(Debug, Clone, PartialEq, ::ruststep_derive::Holder)]
+                #[derive(Debug, Clone, PartialEq, Holder)]
                 #[holder(table = Tables)]
                 #[holder(generate_deserialize)]
                 pub enum #enum_name {

--- a/espr/src/codegen/rust/mod.rs
+++ b/espr/src/codegen/rust/mod.rs
@@ -3,20 +3,14 @@
 mod entity;
 mod schema;
 
-use crate::ir::*;
+pub use entity::*;
+pub use schema::*;
 
 use inflector::Inflector;
 use proc_macro2::TokenStream;
 use quote::*;
 
-impl ToTokens for IR {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let schemas = &self.schemas;
-        tokens.append_all(quote! {
-            #(#schemas)*
-        })
-    }
-}
+use crate::ir::*;
 
 impl ToTokens for Simple {
     fn to_tokens(&self, tokens: &mut TokenStream) {
@@ -95,7 +89,7 @@ impl ToTokens for Select {
             }
         }
         tokens.append_all(quote! {
-            #[derive(Debug, Clone, PartialEq, ::ruststep_derive::Holder)]
+            #[derive(Debug, Clone, PartialEq, Holder)]
             #[holder(table = Tables)]
             #[holder(generate_deserialize)]
             pub enum #id {

--- a/espr/src/codegen/rust/schema.rs
+++ b/espr/src/codegen/rust/schema.rs
@@ -52,7 +52,7 @@ impl Schema {
 
         quote! {
             pub mod #name {
-                use #ruststep_path::{as_holder, TableInit, primitive::*, tables::*, error::Result};
+                use #ruststep_path::{as_holder, Holder, TableInit, primitive::*, tables::*, error::Result};
                 use std::collections::HashMap;
 
                 #[derive(Debug, Clone, PartialEq, Default, TableInit)]

--- a/espr/src/codegen/rust/schema.rs
+++ b/espr/src/codegen/rust/schema.rs
@@ -4,8 +4,34 @@ use inflector::Inflector;
 use proc_macro2::TokenStream;
 use quote::*;
 
-impl ToTokens for Schema {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CratePrefix {
+    Internal,
+    External,
+}
+
+impl CratePrefix {
+    pub fn as_path(&self) -> syn::Path {
+        match self {
+            CratePrefix::Internal => syn::parse_str("crate").unwrap(),
+            CratePrefix::External => syn::parse_str("::ruststep").unwrap(),
+        }
+    }
+}
+
+impl IR {
+    pub fn to_token_stream(&self, prefix: CratePrefix) -> TokenStream {
+        let schemas: Vec<_> = self
+            .schemas
+            .iter()
+            .map(|schema| schema.to_token_stream(prefix))
+            .collect();
+        quote! { #(#schemas)* }
+    }
+}
+
+impl Schema {
+    pub fn to_token_stream(&self, prefix: CratePrefix) -> TokenStream {
         let name = format_ident!("{}", self.name);
         let types = &self.types;
         let entities = &self.entities;
@@ -21,11 +47,13 @@ impl ToTokens for Schema {
             .iter()
             .map(|e| format_ident!("{}_iter", e.name))
             .collect();
-        tokens.append_all(quote! {
+
+        let ruststep_path = prefix.as_path();
+
+        quote! {
             pub mod #name {
-                use crate::{primitive::*, tables::*, error::Result};
+                use #ruststep_path::{as_holder, TableInit, primitive::*, tables::*, error::Result};
                 use std::collections::HashMap;
-                use ruststep_derive::{as_holder, TableInit};
 
                 #[derive(Debug, Clone, PartialEq, Default, TableInit)]
                 pub struct Tables {
@@ -50,6 +78,6 @@ impl ToTokens for Schema {
                 #(#types)*
                 #(#entities)*
             }
-        });
+        }
     }
 }

--- a/ruststep/src/ap201.rs
+++ b/ruststep/src/ap201.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 pub mod explicit_draughting {
-    use crate::{error::Result, primitive::*, tables::*};
-    use ruststep_derive::{as_holder, TableInit};
+    use crate::{as_holder, error::Result, primitive::*, tables::*, Holder, TableInit};
     use std::collections::HashMap;
     #[derive(Debug, Clone, PartialEq, Default, TableInit)]
     pub struct Tables {
@@ -1985,7 +1984,7 @@ pub mod explicit_draughting {
                 .map(move |value| value.into_owned(&self))
         }
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ApprovedItem {
@@ -1995,7 +1994,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         DrawingSheetRevision(Box<DrawingSheetRevision>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum AreaOrView {
@@ -2005,7 +2004,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         PresentationView(Box<PresentationView>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum Axis2Placement {
@@ -2022,7 +2021,7 @@ pub mod explicit_draughting {
         Unspecified,
         HyperbolicArc,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum BoxCharacteristicSelect {
@@ -2035,7 +2034,7 @@ pub mod explicit_draughting {
     pub type BoxRotateAngle = PlaneAngleMeasure;
     pub type BoxSlantAngle = PlaneAngleMeasure;
     pub type BoxWidth = PositiveRatioMeasure;
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CharacterSpacingSelect {
@@ -2044,7 +2043,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         MeasureWithUnit(MeasureWithUnitAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CharacterStyleSelect {
@@ -2052,7 +2051,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         TextStyleForDefinedFont(Box<TextStyleForDefinedFont>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CharacterizedDefinition {
@@ -2061,7 +2060,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         ShapeDefinition(Box<ShapeDefinition>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CharacterizedProductDefinition {
@@ -2069,7 +2068,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         ProductDefinition(Box<ProductDefinition>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ClassifiedItem {
@@ -2079,21 +2078,21 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         DrawingSheetRevision(Box<DrawingSheetRevision>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ContractedItem {
         #[holder(use_place_holder)]
         DrawingRevision(DrawingRevisionAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CurveFontOrScaledCurveFontSelect {
         #[holder(use_place_holder)]
         CurveStyleFontSelect(Box<CurveStyleFontSelect>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CurveOrAnnotationCurveOccurrence {
@@ -2102,7 +2101,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         AnnotationCurveOccurrence(AnnotationCurveOccurrenceAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CurveOrRender {
@@ -2110,7 +2109,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         CurveStyle(Box<CurveStyle>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CurveStyleFontSelect {
@@ -2123,7 +2122,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         ExternallyDefinedCurveFont(Box<ExternallyDefinedCurveFont>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DateTimeSelect {
@@ -2131,7 +2130,7 @@ pub mod explicit_draughting {
         Date(DateAny),
     }
     pub type DayInMonthNumber = i64;
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DefinedSymbolSelect {
@@ -2147,7 +2146,7 @@ pub mod explicit_draughting {
         Origin,
         Target,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DraughtingCalloutElement {
@@ -2159,7 +2158,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         AnnotationCurveOccurrence(AnnotationCurveOccurrenceAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DraughtingGroupedItem {
@@ -2168,7 +2167,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         GeometricSetSelect(Box<GeometricSetSelect>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DraughtingOrganizationItem {
@@ -2181,7 +2180,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         DrawingSheetRevision(Box<DrawingSheetRevision>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DraughtingPresentedItemSelect {
@@ -2189,7 +2188,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         ProductDefinitionFormation(Box<ProductDefinitionFormation>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DraughtingTitledItem {
@@ -2199,7 +2198,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         DrawingSheetRevision(Box<DrawingSheetRevision>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum FillAreaStyleTileShapeSelect {
@@ -2207,7 +2206,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         FillAreaStyleTileSymbolWithStyle(Box<FillAreaStyleTileSymbolWithStyle>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum FillStyleSelect {
@@ -2227,7 +2226,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         FillAreaStyleHatching(Box<FillAreaStyleHatching>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum FontSelect {
@@ -2237,7 +2236,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         ExternallyDefinedTextFont(Box<ExternallyDefinedTextFont>),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum GeometricSetSelect {
@@ -2246,7 +2245,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         Curve(CurveAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum HidingOrBlankingSelect {
@@ -2260,7 +2259,7 @@ pub mod explicit_draughting {
         AnnotationFillArea(Box<AnnotationFillArea>),
     }
     pub type Identifier = String;
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum InvisibilityContext {
@@ -2272,7 +2271,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         PresentationSet(PresentationSetAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum InvisibleItem {
@@ -2292,7 +2291,7 @@ pub mod explicit_draughting {
         Unspecified,
     }
     pub type Label = String;
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum LayeredItem {
@@ -2302,7 +2301,7 @@ pub mod explicit_draughting {
         RepresentationItem(RepresentationItemAny),
     }
     pub type LengthMeasure = f64;
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum MeasureValue {
@@ -2319,7 +2318,7 @@ pub mod explicit_draughting {
         Null,
     }
     pub type ParameterValue = f64;
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PersonOrganizationSelect {
@@ -2337,7 +2336,7 @@ pub mod explicit_draughting {
     pub type PositiveLengthMeasure = LengthMeasure;
     pub type PositiveRatioMeasure = RatioMeasure;
     pub type PresentableText = String;
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PresentationRepresentationSelect {
@@ -2346,7 +2345,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         PresentationSet(PresentationSetAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PresentationSizeAssignmentSelect {
@@ -2358,7 +2357,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         AreaInSet(AreaInSetAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PresentationStyleSelect {
@@ -2376,7 +2375,7 @@ pub mod explicit_draughting {
         NullStyle(NullStyle),
     }
     pub type RatioMeasure = f64;
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ShapeDefinition {
@@ -2434,7 +2433,7 @@ pub mod explicit_draughting {
         Weber,
         Coulomb,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum SizeSelect {
@@ -2442,20 +2441,20 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         MeasureWithUnit(MeasureWithUnitAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum SourceItem {
         Identifier(Identifier),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum SpecifiedItem {
         #[holder(use_place_holder)]
         DrawingRevision(DrawingRevisionAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum StyleContextSelect {
@@ -2466,7 +2465,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         PresentationSet(PresentationSetAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum SymbolStyleSelect {
@@ -2477,7 +2476,7 @@ pub mod explicit_draughting {
     pub type Text = String;
     pub type TextAlignment = Label;
     pub type TextDelineation = Label;
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum TextOrCharacter {
@@ -2509,7 +2508,7 @@ pub mod explicit_draughting {
         Unspecified,
         Cartesian,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum TrimmingSelect {
@@ -2518,14 +2517,14 @@ pub mod explicit_draughting {
         CartesianPoint(Box<CartesianPoint>),
         ParameterValue(ParameterValue),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum Unit {
         #[holder(use_place_holder)]
         NamedUnit(NamedUnitAny),
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum VectorOrDirection {
@@ -2537,7 +2536,7 @@ pub mod explicit_draughting {
         Direction(Box<Direction>),
     }
     pub type YearNumber = i64;
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = address)]
     #[holder(generate_deserialize)]
@@ -2555,7 +2554,7 @@ pub mod explicit_draughting {
         pub electronic_mail_address: Option<Label>,
         pub telex_number: Option<Label>,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum AddressAny {
@@ -2566,17 +2565,17 @@ pub mod explicit_draughting {
         # [holder (field = personal_address)]
         PersonalAddress(Box<PersonalAddress>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = angular_dimension)]
     #[holder(generate_deserialize)]
     pub struct AngularDimension {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = annotation_curve_occurrence)]
     #[holder(generate_deserialize)]
     pub struct AnnotationCurveOccurrence {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum AnnotationCurveOccurrenceAny {
@@ -2590,7 +2589,7 @@ pub mod explicit_draughting {
         # [holder (field = projection_curve)]
         ProjectionCurve(Box<ProjectionCurve>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = annotation_fill_area)]
     #[holder(generate_deserialize)]
@@ -2598,7 +2597,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub boundaries: Vec<CurveAny>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = annotation_fill_area_occurrence)]
     #[holder(generate_deserialize)]
@@ -2606,12 +2605,12 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub fill_style_target: PointAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = annotation_occurrence)]
     #[holder(generate_deserialize)]
     pub struct AnnotationOccurrence {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum AnnotationOccurrenceAny {
@@ -2631,22 +2630,22 @@ pub mod explicit_draughting {
         # [holder (field = draughting_annotation_occurrence)]
         DraughtingAnnotationOccurrence(Box<DraughtingAnnotationOccurrence>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = annotation_subfigure_occurrence)]
     #[holder(generate_deserialize)]
     pub struct AnnotationSubfigureOccurrence {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = annotation_symbol)]
     #[holder(generate_deserialize)]
     pub struct AnnotationSymbol {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = annotation_symbol_occurrence)]
     #[holder(generate_deserialize)]
     pub struct AnnotationSymbolOccurrence {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum AnnotationSymbolOccurrenceAny {
@@ -2657,24 +2656,24 @@ pub mod explicit_draughting {
         # [holder (field = terminator_symbol)]
         TerminatorSymbol(Box<TerminatorSymbol>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = annotation_text)]
     #[holder(generate_deserialize)]
     pub struct AnnotationText {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = annotation_text_occurrence)]
     #[holder(generate_deserialize)]
     pub struct AnnotationTextOccurrence {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = application_context)]
     #[holder(generate_deserialize)]
     pub struct ApplicationContext {
         pub application: Text,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = application_context_element)]
     #[holder(generate_deserialize)]
@@ -2683,7 +2682,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub frame_of_reference: ApplicationContext,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ApplicationContextElementAny {
@@ -2694,7 +2693,7 @@ pub mod explicit_draughting {
         # [holder (field = product_definition_context)]
         ProductDefinitionContext(Box<ProductDefinitionContext>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = application_protocol_definition)]
     #[holder(generate_deserialize)]
@@ -2705,7 +2704,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub application: ApplicationContext,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = approval)]
     #[holder(generate_deserialize)]
@@ -2714,7 +2713,7 @@ pub mod explicit_draughting {
         pub status: ApprovalStatus,
         pub level: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = approval_assignment)]
     #[holder(generate_deserialize)]
@@ -2722,7 +2721,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub assigned_approval: Approval,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ApprovalAssignmentAny {
@@ -2730,7 +2729,7 @@ pub mod explicit_draughting {
         # [holder (field = draughting_approval_assignment)]
         DraughtingApprovalAssignment(Box<DraughtingApprovalAssignment>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = approval_date_time)]
     #[holder(generate_deserialize)]
@@ -2740,7 +2739,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub dated_approval: Approval,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = approval_person_organization)]
     #[holder(generate_deserialize)]
@@ -2752,21 +2751,21 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub role: ApprovalRole,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = approval_role)]
     #[holder(generate_deserialize)]
     pub struct ApprovalRole {
         pub role: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = approval_status)]
     #[holder(generate_deserialize)]
     pub struct ApprovalStatus {
         pub name: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = area_in_set)]
     #[holder(generate_deserialize)]
@@ -2776,7 +2775,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub in_set: PresentationSetAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum AreaInSetAny {
@@ -2784,7 +2783,7 @@ pub mod explicit_draughting {
         # [holder (field = drawing_sheet_revision_usage)]
         DrawingSheetRevisionUsage(Box<DrawingSheetRevisionUsage>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = axis2_placement_2d)]
     #[holder(generate_deserialize)]
@@ -2792,7 +2791,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub ref_direction: Option<Direction>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = b_spline_curve)]
     #[holder(generate_deserialize)]
@@ -2804,7 +2803,7 @@ pub mod explicit_draughting {
         pub closed_curve: Logical,
         pub self_intersect: Logical,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum BSplineCurveAny {
@@ -2824,7 +2823,7 @@ pub mod explicit_draughting {
         # [holder (field = uniform_curve)]
         UniformCurve(Box<UniformCurve>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = b_spline_curve_with_knots)]
     #[holder(generate_deserialize)]
@@ -2833,17 +2832,17 @@ pub mod explicit_draughting {
         pub knots: Vec<ParameterValue>,
         pub knot_spec: KnotType,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = bezier_curve)]
     #[holder(generate_deserialize)]
     pub struct BezierCurve {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = bounded_curve)]
     #[holder(generate_deserialize)]
     pub struct BoundedCurve {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum BoundedCurveAny {
@@ -2860,7 +2859,7 @@ pub mod explicit_draughting {
         # [holder (field = trimmed_curve)]
         TrimmedCurve(Box<TrimmedCurve>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = calendar_date)]
     #[holder(generate_deserialize)]
@@ -2868,12 +2867,12 @@ pub mod explicit_draughting {
         pub day_component: DayInMonthNumber,
         pub month_component: MonthInYearNumber,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = camera_image)]
     #[holder(generate_deserialize)]
     pub struct CameraImage {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CameraImageAny {
@@ -2881,17 +2880,17 @@ pub mod explicit_draughting {
         # [holder (field = camera_image_2d_with_scale)]
         CameraImage2DWithScale(Box<CameraImage2DWithScale>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = camera_image_2d_with_scale)]
     #[holder(generate_deserialize)]
     pub struct CameraImage2DWithScale {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = camera_model)]
     #[holder(generate_deserialize)]
     pub struct CameraModel {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CameraModelAny {
@@ -2899,7 +2898,7 @@ pub mod explicit_draughting {
         # [holder (field = camera_model_d2)]
         CameraModelD2(Box<CameraModelD2>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = camera_model_d2)]
     #[holder(generate_deserialize)]
@@ -2908,31 +2907,31 @@ pub mod explicit_draughting {
         pub view_window: PlanarBox,
         pub view_window_clipping: bool,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = camera_usage)]
     #[holder(generate_deserialize)]
     pub struct CameraUsage {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = cartesian_point)]
     #[holder(generate_deserialize)]
     pub struct CartesianPoint {
         pub coordinates: Vec<LengthMeasure>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = circle)]
     #[holder(generate_deserialize)]
     pub struct Circle {
         pub radius: PositiveLengthMeasure,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = colour)]
     #[holder(generate_deserialize)]
     pub struct Colour {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ColourAny {
@@ -2943,7 +2942,7 @@ pub mod explicit_draughting {
         # [holder (field = pre_defined_colour)]
         PreDefinedColour(Box<PreDefinedColour>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = colour_rgb)]
     #[holder(generate_deserialize)]
@@ -2952,7 +2951,7 @@ pub mod explicit_draughting {
         pub green: f64,
         pub blue: f64,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = colour_specification)]
     #[holder(generate_deserialize)]
@@ -2960,7 +2959,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub name: ColourAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ColourSpecificationAny {
@@ -2968,7 +2967,7 @@ pub mod explicit_draughting {
         # [holder (field = colour_rgb)]
         ColourRgb(Box<ColourRgb>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = composite_curve)]
     #[holder(generate_deserialize)]
@@ -2977,7 +2976,7 @@ pub mod explicit_draughting {
         pub segments: Vec<CompositeCurveSegment>,
         pub self_intersect: Logical,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = composite_curve_segment)]
     #[holder(generate_deserialize)]
@@ -2987,7 +2986,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub parent_curve: CurveAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = composite_text)]
     #[holder(generate_deserialize)]
@@ -2995,7 +2994,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub collected_text: Vec<TextOrCharacter>,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CompositeTextAny {
@@ -3009,7 +3008,7 @@ pub mod explicit_draughting {
         # [holder (field = composite_text_with_extent)]
         CompositeTextWithExtent(Box<CompositeTextWithExtent>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = composite_text_with_associated_curves)]
     #[holder(generate_deserialize)]
@@ -3017,7 +3016,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub associated_curves: Vec<CurveAny>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = composite_text_with_blanking_box)]
     #[holder(generate_deserialize)]
@@ -3025,7 +3024,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub blanking: PlanarBox,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = composite_text_with_extent)]
     #[holder(generate_deserialize)]
@@ -3033,7 +3032,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub extent: PlanarExtentAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = conic)]
     #[holder(generate_deserialize)]
@@ -3041,7 +3040,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub position: Axis2Placement,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ConicAny {
@@ -3058,7 +3057,7 @@ pub mod explicit_draughting {
         # [holder (field = parabola)]
         Parabola(Box<Parabola>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = context_dependent_invisibility)]
     #[holder(generate_deserialize)]
@@ -3066,7 +3065,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub presentation_context: InvisibilityContext,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = contract)]
     #[holder(generate_deserialize)]
@@ -3076,7 +3075,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub kind: ContractType,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = contract_assignment)]
     #[holder(generate_deserialize)]
@@ -3084,7 +3083,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub assigned_contract: Contract,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ContractAssignmentAny {
@@ -3092,14 +3091,14 @@ pub mod explicit_draughting {
         # [holder (field = draughting_contract_assignment)]
         DraughtingContractAssignment(Box<DraughtingContractAssignment>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = contract_type)]
     #[holder(generate_deserialize)]
     pub struct ContractType {
         pub description: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = conversion_based_unit)]
     #[holder(generate_deserialize)]
@@ -3108,12 +3107,12 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub conversion_factor: MeasureWithUnitAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = curve)]
     #[holder(generate_deserialize)]
     pub struct Curve {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum CurveAny {
@@ -3130,12 +3129,12 @@ pub mod explicit_draughting {
         # [holder (field = offset_curve_2d)]
         OffsetCurve2D(Box<OffsetCurve2D>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = curve_dimension)]
     #[holder(generate_deserialize)]
     pub struct CurveDimension {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = curve_style)]
     #[holder(generate_deserialize)]
@@ -3148,7 +3147,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub curve_colour: ColourAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = curve_style_font)]
     #[holder(generate_deserialize)]
@@ -3157,7 +3156,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub pattern_list: Vec<CurveStyleFontPattern>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = curve_style_font_pattern)]
     #[holder(generate_deserialize)]
@@ -3165,14 +3164,14 @@ pub mod explicit_draughting {
         pub visible_segment_length: PositiveLengthMeasure,
         pub invisible_segment_length: PositiveLengthMeasure,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = date)]
     #[holder(generate_deserialize)]
     pub struct Date {
         pub year_component: YearNumber,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DateAny {
@@ -3180,17 +3179,17 @@ pub mod explicit_draughting {
         # [holder (field = calendar_date)]
         CalendarDate(Box<CalendarDate>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = datum_feature_callout)]
     #[holder(generate_deserialize)]
     pub struct DatumFeatureCallout {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = datum_target_callout)]
     #[holder(generate_deserialize)]
     pub struct DatumTargetCallout {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = defined_symbol)]
     #[holder(generate_deserialize)]
@@ -3200,32 +3199,32 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub target: SymbolTarget,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = diameter_dimension)]
     #[holder(generate_deserialize)]
     pub struct DiameterDimension {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = dimension_callout_component_relationship)]
     #[holder(generate_deserialize)]
     pub struct DimensionCalloutComponentRelationship {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = dimension_callout_relationship)]
     #[holder(generate_deserialize)]
     pub struct DimensionCalloutRelationship {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = dimension_curve)]
     #[holder(generate_deserialize)]
     pub struct DimensionCurve {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = dimension_curve_directed_callout)]
     #[holder(generate_deserialize)]
     pub struct DimensionCurveDirectedCallout {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DimensionCurveDirectedCalloutAny {
@@ -3245,19 +3244,19 @@ pub mod explicit_draughting {
         # [holder (field = radius_dimension)]
         RadiusDimension(Box<RadiusDimension>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = dimension_curve_terminator)]
     #[holder(generate_deserialize)]
     pub struct DimensionCurveTerminator {
         pub role: DimensionExtentUsage,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = dimension_pair)]
     #[holder(generate_deserialize)]
     pub struct DimensionPair {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = dimensional_exponents)]
     #[holder(generate_deserialize)]
@@ -3270,14 +3269,14 @@ pub mod explicit_draughting {
         pub amount_of_substance_exponent: f64,
         pub luminous_intensity_exponent: f64,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = direction)]
     #[holder(generate_deserialize)]
     pub struct Direction {
         pub direction_ratios: Vec<f64>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = document)]
     #[holder(generate_deserialize)]
@@ -3288,7 +3287,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub kind: DocumentType,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = document_reference)]
     #[holder(generate_deserialize)]
@@ -3297,7 +3296,7 @@ pub mod explicit_draughting {
         pub assigned_document: Document,
         pub source: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DocumentReferenceAny {
@@ -3305,19 +3304,19 @@ pub mod explicit_draughting {
         # [holder (field = draughting_specification_reference)]
         DraughtingSpecificationReference(Box<DraughtingSpecificationReference>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = document_type)]
     #[holder(generate_deserialize)]
     pub struct DocumentType {
         pub product_data_type: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_annotation_occurrence)]
     #[holder(generate_deserialize)]
     pub struct DraughtingAnnotationOccurrence {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_approval_assignment)]
     #[holder(generate_deserialize)]
@@ -3325,7 +3324,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub approved_items: Vec<ApprovedItem>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_callout)]
     #[holder(generate_deserialize)]
@@ -3333,7 +3332,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub contents: Vec<DraughtingCalloutElement>,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DraughtingCalloutAny {
@@ -3362,7 +3361,7 @@ pub mod explicit_draughting {
         # [holder (field = structured_dimension_callout)]
         StructuredDimensionCallout(Box<StructuredDimensionCallout>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_callout_relationship)]
     #[holder(generate_deserialize)]
@@ -3374,7 +3373,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub related_draughting_callout: DraughtingCalloutAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DraughtingCalloutRelationshipAny {
@@ -3388,7 +3387,7 @@ pub mod explicit_draughting {
         # [holder (field = dimension_pair)]
         DimensionPair(Box<DimensionPair>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_contract_assignment)]
     #[holder(generate_deserialize)]
@@ -3396,17 +3395,17 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub items: Vec<ContractedItem>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_drawing_revision)]
     #[holder(generate_deserialize)]
     pub struct DraughtingDrawingRevision {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_elements)]
     #[holder(generate_deserialize)]
     pub struct DraughtingElements {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_group_assignment)]
     #[holder(generate_deserialize)]
@@ -3414,12 +3413,12 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub items: Vec<DraughtingGroupedItem>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_model)]
     #[holder(generate_deserialize)]
     pub struct DraughtingModel {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_organization_assignment)]
     #[holder(generate_deserialize)]
@@ -3427,7 +3426,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub assigned_items: Vec<DraughtingOrganizationItem>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_person_and_organization_assignment)]
     #[holder(generate_deserialize)]
@@ -3435,7 +3434,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub assigned_items: Vec<DraughtingOrganizationItem>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_person_assignment)]
     #[holder(generate_deserialize)]
@@ -3443,22 +3442,22 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub assigned_items: Vec<DraughtingOrganizationItem>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_pre_defined_colour)]
     #[holder(generate_deserialize)]
     pub struct DraughtingPreDefinedColour {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_pre_defined_curve_font)]
     #[holder(generate_deserialize)]
     pub struct DraughtingPreDefinedCurveFont {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_pre_defined_text_font)]
     #[holder(generate_deserialize)]
     pub struct DraughtingPreDefinedTextFont {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_presented_item)]
     #[holder(generate_deserialize)]
@@ -3466,7 +3465,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub items: Vec<DraughtingPresentedItemSelect>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_security_classification_assignment)]
     #[holder(generate_deserialize)]
@@ -3474,7 +3473,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub assigned_items: Vec<ClassifiedItem>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_specification_reference)]
     #[holder(generate_deserialize)]
@@ -3482,17 +3481,17 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub specified_items: Vec<SpecifiedItem>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_subfigure_representation)]
     #[holder(generate_deserialize)]
     pub struct DraughtingSubfigureRepresentation {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_symbol_representation)]
     #[holder(generate_deserialize)]
     pub struct DraughtingSymbolRepresentation {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DraughtingSymbolRepresentationAny {
@@ -3500,12 +3499,12 @@ pub mod explicit_draughting {
         # [holder (field = drawing_sheet_layout)]
         DrawingSheetLayout(Box<DrawingSheetLayout>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_text_literal_with_delineation)]
     #[holder(generate_deserialize)]
     pub struct DraughtingTextLiteralWithDelineation {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = draughting_title)]
     #[holder(generate_deserialize)]
@@ -3515,7 +3514,7 @@ pub mod explicit_draughting {
         pub language: Label,
         pub contents: Text,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = drawing_definition)]
     #[holder(generate_deserialize)]
@@ -3523,7 +3522,7 @@ pub mod explicit_draughting {
         pub drawing_number: Identifier,
         pub drawing_type: Option<Label>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = drawing_revision)]
     #[holder(generate_deserialize)]
@@ -3533,7 +3532,7 @@ pub mod explicit_draughting {
         pub drawing_identifier: DrawingDefinition,
         pub intended_scale: Option<Text>,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum DrawingRevisionAny {
@@ -3541,26 +3540,26 @@ pub mod explicit_draughting {
         # [holder (field = draughting_drawing_revision)]
         DraughtingDrawingRevision(Box<DraughtingDrawingRevision>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = drawing_sheet_layout)]
     #[holder(generate_deserialize)]
     pub struct DrawingSheetLayout {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = drawing_sheet_revision)]
     #[holder(generate_deserialize)]
     pub struct DrawingSheetRevision {
         pub revision_identifier: Identifier,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = drawing_sheet_revision_usage)]
     #[holder(generate_deserialize)]
     pub struct DrawingSheetRevisionUsage {
         pub sheet_number: Identifier,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = ellipse)]
     #[holder(generate_deserialize)]
@@ -3568,7 +3567,7 @@ pub mod explicit_draughting {
         pub semi_axis_1: PositiveLengthMeasure,
         pub semi_axis_2: PositiveLengthMeasure,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = external_source)]
     #[holder(generate_deserialize)]
@@ -3576,17 +3575,17 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub source_id: SourceItem,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = externally_defined_curve_font)]
     #[holder(generate_deserialize)]
     pub struct ExternallyDefinedCurveFont {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = externally_defined_hatch_style)]
     #[holder(generate_deserialize)]
     pub struct ExternallyDefinedHatchStyle {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = externally_defined_item)]
     #[holder(generate_deserialize)]
@@ -3596,7 +3595,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub source: ExternalSource,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ExternallyDefinedItemAny {
@@ -3616,22 +3615,22 @@ pub mod explicit_draughting {
         # [holder (field = externally_defined_tile_style)]
         ExternallyDefinedTileStyle(Box<ExternallyDefinedTileStyle>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = externally_defined_symbol)]
     #[holder(generate_deserialize)]
     pub struct ExternallyDefinedSymbol {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = externally_defined_text_font)]
     #[holder(generate_deserialize)]
     pub struct ExternallyDefinedTextFont {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = externally_defined_tile_style)]
     #[holder(generate_deserialize)]
     pub struct ExternallyDefinedTileStyle {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = fill_area_style)]
     #[holder(generate_deserialize)]
@@ -3640,7 +3639,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub fill_styles: Vec<FillStyleSelect>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = fill_area_style_colour)]
     #[holder(generate_deserialize)]
@@ -3649,7 +3648,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub fill_colour: ColourAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = fill_area_style_hatching)]
     #[holder(generate_deserialize)]
@@ -3664,7 +3663,7 @@ pub mod explicit_draughting {
         pub pattern_start: CartesianPoint,
         pub hatch_line_angle: PlaneAngleMeasure,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = fill_area_style_tile_symbol_with_style)]
     #[holder(generate_deserialize)]
@@ -3672,7 +3671,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub symbol: AnnotationSymbolOccurrenceAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = fill_area_style_tiles)]
     #[holder(generate_deserialize)]
@@ -3683,24 +3682,24 @@ pub mod explicit_draughting {
         pub tiles: Vec<FillAreaStyleTileShapeSelect>,
         pub tiling_scale: PositiveRatioMeasure,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = geometric_curve_set)]
     #[holder(generate_deserialize)]
     pub struct GeometricCurveSet {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = geometric_representation_context)]
     #[holder(generate_deserialize)]
     pub struct GeometricRepresentationContext {
         pub coordinate_space_dimension: DimensionCount,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = geometric_representation_item)]
     #[holder(generate_deserialize)]
     pub struct GeometricRepresentationItem {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum GeometricRepresentationItemAny {
@@ -3765,7 +3764,7 @@ pub mod explicit_draughting {
         # [holder (field = vector)]
         Vector(Box<Vector>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = geometric_set)]
     #[holder(generate_deserialize)]
@@ -3773,7 +3772,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub elements: Vec<GeometricSetSelect>,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum GeometricSetAny {
@@ -3781,17 +3780,17 @@ pub mod explicit_draughting {
         # [holder (field = geometric_curve_set)]
         GeometricCurveSet(Box<GeometricCurveSet>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = geometrical_tolerance_callout)]
     #[holder(generate_deserialize)]
     pub struct GeometricalToleranceCallout {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = geometrically_bounded_2d_wireframe_representation)]
     #[holder(generate_deserialize)]
     pub struct GeometricallyBounded2DWireframeRepresentation {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = global_unit_assigned_context)]
     #[holder(generate_deserialize)]
@@ -3799,7 +3798,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub units: Vec<Unit>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = group)]
     #[holder(generate_deserialize)]
@@ -3807,7 +3806,7 @@ pub mod explicit_draughting {
         pub name: Label,
         pub description: Text,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = group_assignment)]
     #[holder(generate_deserialize)]
@@ -3815,7 +3814,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub assigned_group: Group,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum GroupAssignmentAny {
@@ -3823,7 +3822,7 @@ pub mod explicit_draughting {
         # [holder (field = draughting_group_assignment)]
         DraughtingGroupAssignment(Box<DraughtingGroupAssignment>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = group_relationship)]
     #[holder(generate_deserialize)]
@@ -3835,7 +3834,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub related_group: Group,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = hyperbola)]
     #[holder(generate_deserialize)]
@@ -3843,7 +3842,7 @@ pub mod explicit_draughting {
         pub semi_axis: PositiveLengthMeasure,
         pub semi_imag_axis: PositiveLengthMeasure,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = invisibility)]
     #[holder(generate_deserialize)]
@@ -3851,7 +3850,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub invisible_items: Vec<InvisibleItem>,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum InvisibilityAny {
@@ -3859,17 +3858,17 @@ pub mod explicit_draughting {
         # [holder (field = context_dependent_invisibility)]
         ContextDependentInvisibility(Box<ContextDependentInvisibility>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = leader_curve)]
     #[holder(generate_deserialize)]
     pub struct LeaderCurve {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = leader_directed_callout)]
     #[holder(generate_deserialize)]
     pub struct LeaderDirectedCallout {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum LeaderDirectedCalloutAny {
@@ -3877,27 +3876,27 @@ pub mod explicit_draughting {
         # [holder (field = leader_directed_dimension)]
         LeaderDirectedDimension(Box<LeaderDirectedDimension>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = leader_directed_dimension)]
     #[holder(generate_deserialize)]
     pub struct LeaderDirectedDimension {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = leader_terminator)]
     #[holder(generate_deserialize)]
     pub struct LeaderTerminator {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = length_measure_with_unit)]
     #[holder(generate_deserialize)]
     pub struct LengthMeasureWithUnit {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = length_unit)]
     #[holder(generate_deserialize)]
     pub struct LengthUnit {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = line)]
     #[holder(generate_deserialize)]
@@ -3907,12 +3906,12 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub dir: Vector,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = linear_dimension)]
     #[holder(generate_deserialize)]
     pub struct LinearDimension {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = mapped_item)]
     #[holder(generate_deserialize)]
@@ -3922,7 +3921,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub mapping_target: RepresentationItemAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum MappedItemAny {
@@ -3936,7 +3935,7 @@ pub mod explicit_draughting {
         # [holder (field = camera_image)]
         CameraImage(Box<CameraImage>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = measure_with_unit)]
     #[holder(generate_deserialize)]
@@ -3946,7 +3945,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub unit_component: Unit,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum MeasureWithUnitAny {
@@ -3957,7 +3956,7 @@ pub mod explicit_draughting {
         # [holder (field = plane_angle_measure_with_unit)]
         PlaneAngleMeasureWithUnit(Box<PlaneAngleMeasureWithUnit>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = named_unit)]
     #[holder(generate_deserialize)]
@@ -3965,7 +3964,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub dimensions: DimensionalExponents,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum NamedUnitAny {
@@ -3982,7 +3981,7 @@ pub mod explicit_draughting {
         # [holder (field = si_unit)]
         SiUnit(Box<SiUnit>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = offset_curve_2d)]
     #[holder(generate_deserialize)]
@@ -3992,7 +3991,7 @@ pub mod explicit_draughting {
         pub distance: LengthMeasure,
         pub self_intersect: Logical,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = one_direction_repeat_factor)]
     #[holder(generate_deserialize)]
@@ -4000,7 +3999,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub repeat_factor: Vector,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum OneDirectionRepeatFactorAny {
@@ -4008,12 +4007,12 @@ pub mod explicit_draughting {
         # [holder (field = two_direction_repeat_factor)]
         TwoDirectionRepeatFactor(Box<TwoDirectionRepeatFactor>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = ordinate_dimension)]
     #[holder(generate_deserialize)]
     pub struct OrdinateDimension {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = organization)]
     #[holder(generate_deserialize)]
@@ -4022,7 +4021,7 @@ pub mod explicit_draughting {
         pub name: Label,
         pub description: Text,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = organization_assignment)]
     #[holder(generate_deserialize)]
@@ -4032,7 +4031,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub role: OrganizationRole,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum OrganizationAssignmentAny {
@@ -4040,14 +4039,14 @@ pub mod explicit_draughting {
         # [holder (field = draughting_organization_assignment)]
         DraughtingOrganizationAssignment(Box<DraughtingOrganizationAssignment>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = organization_role)]
     #[holder(generate_deserialize)]
     pub struct OrganizationRole {
         pub name: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = organizational_address)]
     #[holder(generate_deserialize)]
@@ -4056,14 +4055,14 @@ pub mod explicit_draughting {
         pub organizations: Vec<Organization>,
         pub description: Text,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = parabola)]
     #[holder(generate_deserialize)]
     pub struct Parabola {
         pub focal_dist: LengthMeasure,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = person)]
     #[holder(generate_deserialize)]
@@ -4075,7 +4074,7 @@ pub mod explicit_draughting {
         pub prefix_titles: Option<Vec<Label>>,
         pub suffix_titles: Option<Vec<Label>>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = person_and_organization)]
     #[holder(generate_deserialize)]
@@ -4085,7 +4084,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub the_organization: Organization,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = person_and_organization_assignment)]
     #[holder(generate_deserialize)]
@@ -4095,7 +4094,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub role: PersonAndOrganizationRole,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PersonAndOrganizationAssignmentAny {
@@ -4103,14 +4102,14 @@ pub mod explicit_draughting {
         # [holder (field = draughting_person_and_organization_assignment)]
         DraughtingPersonAndOrganizationAssignment(Box<DraughtingPersonAndOrganizationAssignment>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = person_and_organization_role)]
     #[holder(generate_deserialize)]
     pub struct PersonAndOrganizationRole {
         pub name: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = person_assignment)]
     #[holder(generate_deserialize)]
@@ -4120,7 +4119,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub role: PersonRole,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PersonAssignmentAny {
@@ -4128,14 +4127,14 @@ pub mod explicit_draughting {
         # [holder (field = draughting_person_assignment)]
         DraughtingPersonAssignment(Box<DraughtingPersonAssignment>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = person_role)]
     #[holder(generate_deserialize)]
     pub struct PersonRole {
         pub name: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = personal_address)]
     #[holder(generate_deserialize)]
@@ -4144,7 +4143,7 @@ pub mod explicit_draughting {
         pub people: Vec<Person>,
         pub description: Text,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = placement)]
     #[holder(generate_deserialize)]
@@ -4152,7 +4151,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub location: CartesianPoint,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PlacementAny {
@@ -4160,7 +4159,7 @@ pub mod explicit_draughting {
         # [holder (field = axis2_placement_2d)]
         Axis2Placement2D(Box<Axis2Placement2D>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = planar_box)]
     #[holder(generate_deserialize)]
@@ -4168,7 +4167,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub placement: Axis2Placement,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = planar_extent)]
     #[holder(generate_deserialize)]
@@ -4176,7 +4175,7 @@ pub mod explicit_draughting {
         pub size_in_x: LengthMeasure,
         pub size_in_y: LengthMeasure,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PlanarExtentAny {
@@ -4184,22 +4183,22 @@ pub mod explicit_draughting {
         # [holder (field = planar_box)]
         PlanarBox(Box<PlanarBox>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = plane_angle_measure_with_unit)]
     #[holder(generate_deserialize)]
     pub struct PlaneAngleMeasureWithUnit {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = plane_angle_unit)]
     #[holder(generate_deserialize)]
     pub struct PlaneAngleUnit {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = point)]
     #[holder(generate_deserialize)]
     pub struct Point {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PointAny {
@@ -4210,7 +4209,7 @@ pub mod explicit_draughting {
         # [holder (field = point_on_curve)]
         PointOnCurve(Box<PointOnCurve>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = point_on_curve)]
     #[holder(generate_deserialize)]
@@ -4219,7 +4218,7 @@ pub mod explicit_draughting {
         pub basis_curve: CurveAny,
         pub point_parameter: ParameterValue,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = polyline)]
     #[holder(generate_deserialize)]
@@ -4227,12 +4226,12 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub points: Vec<CartesianPoint>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_colour)]
     #[holder(generate_deserialize)]
     pub struct PreDefinedColour {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PreDefinedColourAny {
@@ -4240,12 +4239,12 @@ pub mod explicit_draughting {
         # [holder (field = draughting_pre_defined_colour)]
         DraughtingPreDefinedColour(Box<DraughtingPreDefinedColour>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_curve_font)]
     #[holder(generate_deserialize)]
     pub struct PreDefinedCurveFont {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PreDefinedCurveFontAny {
@@ -4253,24 +4252,24 @@ pub mod explicit_draughting {
         # [holder (field = draughting_pre_defined_curve_font)]
         DraughtingPreDefinedCurveFont(Box<DraughtingPreDefinedCurveFont>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_dimension_symbol)]
     #[holder(generate_deserialize)]
     pub struct PreDefinedDimensionSymbol {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_geometrical_tolerance_symbol)]
     #[holder(generate_deserialize)]
     pub struct PreDefinedGeometricalToleranceSymbol {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_item)]
     #[holder(generate_deserialize)]
     pub struct PreDefinedItem {
         pub name: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PreDefinedItemAny {
@@ -4287,17 +4286,17 @@ pub mod explicit_draughting {
         # [holder (field = pre_defined_text_font)]
         PreDefinedTextFont(Box<PreDefinedTextFont>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_point_marker_symbol)]
     #[holder(generate_deserialize)]
     pub struct PreDefinedPointMarkerSymbol {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_symbol)]
     #[holder(generate_deserialize)]
     pub struct PreDefinedSymbol {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PreDefinedSymbolAny {
@@ -4314,17 +4313,17 @@ pub mod explicit_draughting {
         # [holder (field = pre_defined_terminator_symbol)]
         PreDefinedTerminatorSymbol(Box<PreDefinedTerminatorSymbol>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_terminator_symbol)]
     #[holder(generate_deserialize)]
     pub struct PreDefinedTerminatorSymbol {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_text_font)]
     #[holder(generate_deserialize)]
     pub struct PreDefinedTextFont {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PreDefinedTextFontAny {
@@ -4332,12 +4331,12 @@ pub mod explicit_draughting {
         # [holder (field = draughting_pre_defined_text_font)]
         DraughtingPreDefinedTextFont(Box<DraughtingPreDefinedTextFont>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = presentation_area)]
     #[holder(generate_deserialize)]
     pub struct PresentationArea {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PresentationAreaAny {
@@ -4345,7 +4344,7 @@ pub mod explicit_draughting {
         # [holder (field = drawing_sheet_revision)]
         DrawingSheetRevision(Box<DrawingSheetRevision>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = presentation_layer_assignment)]
     #[holder(generate_deserialize)]
@@ -4355,7 +4354,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub assigned_items: Vec<LayeredItem>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = presentation_layer_usage)]
     #[holder(generate_deserialize)]
@@ -4365,12 +4364,12 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub presentation: PresentationRepresentationAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = presentation_representation)]
     #[holder(generate_deserialize)]
     pub struct PresentationRepresentation {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PresentationRepresentationAny {
@@ -4381,12 +4380,12 @@ pub mod explicit_draughting {
         # [holder (field = presentation_view)]
         PresentationView(Box<PresentationView>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = presentation_set)]
     #[holder(generate_deserialize)]
     pub struct PresentationSet {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PresentationSetAny {
@@ -4394,7 +4393,7 @@ pub mod explicit_draughting {
         # [holder (field = drawing_revision)]
         DrawingRevision(Box<DrawingRevision>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = presentation_size)]
     #[holder(generate_deserialize)]
@@ -4404,7 +4403,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub size: PlanarBox,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = presentation_style_assignment)]
     #[holder(generate_deserialize)]
@@ -4412,7 +4411,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub styles: Vec<PresentationStyleSelect>,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PresentationStyleAssignmentAny {
@@ -4420,7 +4419,7 @@ pub mod explicit_draughting {
         # [holder (field = presentation_style_by_context)]
         PresentationStyleByContext(Box<PresentationStyleByContext>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = presentation_style_by_context)]
     #[holder(generate_deserialize)]
@@ -4428,17 +4427,17 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub style_context: StyleContextSelect,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = presentation_view)]
     #[holder(generate_deserialize)]
     pub struct PresentationView {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = presented_item)]
     #[holder(generate_deserialize)]
     pub struct PresentedItem {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PresentedItemAny {
@@ -4446,7 +4445,7 @@ pub mod explicit_draughting {
         # [holder (field = draughting_presented_item)]
         DraughtingPresentedItem(Box<DraughtingPresentedItem>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = presented_item_representation)]
     #[holder(generate_deserialize)]
@@ -4456,7 +4455,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub item: PresentedItemAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = product)]
     #[holder(generate_deserialize)]
@@ -4467,14 +4466,14 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub frame_of_reference: Vec<ProductContext>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = product_context)]
     #[holder(generate_deserialize)]
     pub struct ProductContext {
         pub discipline_type: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = product_definition)]
     #[holder(generate_deserialize)]
@@ -4486,14 +4485,14 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub frame_of_reference: ProductDefinitionContext,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = product_definition_context)]
     #[holder(generate_deserialize)]
     pub struct ProductDefinitionContext {
         pub life_cycle_stage: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = product_definition_formation)]
     #[holder(generate_deserialize)]
@@ -4503,22 +4502,22 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub of_product: Product,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = product_definition_shape)]
     #[holder(generate_deserialize)]
     pub struct ProductDefinitionShape {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = projection_curve)]
     #[holder(generate_deserialize)]
     pub struct ProjectionCurve {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = projection_directed_callout)]
     #[holder(generate_deserialize)]
     pub struct ProjectionDirectedCallout {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ProjectionDirectedCalloutAny {
@@ -4526,7 +4525,7 @@ pub mod explicit_draughting {
         # [holder (field = ordinate_dimension)]
         OrdinateDimension(Box<OrdinateDimension>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = property_definition)]
     #[holder(generate_deserialize)]
@@ -4536,7 +4535,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub definition: CharacterizedDefinition,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PropertyDefinitionAny {
@@ -4544,7 +4543,7 @@ pub mod explicit_draughting {
         # [holder (field = product_definition_shape)]
         ProductDefinitionShape(Box<ProductDefinitionShape>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = property_definition_representation)]
     #[holder(generate_deserialize)]
@@ -4554,7 +4553,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub used_representation: RepresentationAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum PropertyDefinitionRepresentationAny {
@@ -4562,24 +4561,24 @@ pub mod explicit_draughting {
         # [holder (field = shape_definition_representation)]
         ShapeDefinitionRepresentation(Box<ShapeDefinitionRepresentation>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = quasi_uniform_curve)]
     #[holder(generate_deserialize)]
     pub struct QuasiUniformCurve {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = radius_dimension)]
     #[holder(generate_deserialize)]
     pub struct RadiusDimension {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = rational_b_spline_curve)]
     #[holder(generate_deserialize)]
     pub struct RationalBSplineCurve {
         pub weights_data: Vec<f64>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = representation)]
     #[holder(generate_deserialize)]
@@ -4590,7 +4589,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub context_of_items: RepresentationContextAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum RepresentationAny {
@@ -4607,7 +4606,7 @@ pub mod explicit_draughting {
         # [holder (field = symbol_representation)]
         SymbolRepresentation(Box<SymbolRepresentation>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = representation_context)]
     #[holder(generate_deserialize)]
@@ -4615,7 +4614,7 @@ pub mod explicit_draughting {
         pub context_identifier: Identifier,
         pub context_type: Text,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum RepresentationContextAny {
@@ -4626,14 +4625,14 @@ pub mod explicit_draughting {
         # [holder (field = global_unit_assigned_context)]
         GlobalUnitAssignedContext(Box<GlobalUnitAssignedContext>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = representation_item)]
     #[holder(generate_deserialize)]
     pub struct RepresentationItem {
         pub name: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum RepresentationItemAny {
@@ -4647,7 +4646,7 @@ pub mod explicit_draughting {
         # [holder (field = styled_item)]
         StyledItem(Box<StyledItem>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = representation_map)]
     #[holder(generate_deserialize)]
@@ -4657,7 +4656,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub mapped_representation: RepresentationAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum RepresentationMapAny {
@@ -4668,7 +4667,7 @@ pub mod explicit_draughting {
         # [holder (field = symbol_representation_map)]
         SymbolRepresentationMap(Box<SymbolRepresentationMap>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = security_classification)]
     #[holder(generate_deserialize)]
@@ -4678,7 +4677,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub security_level: SecurityClassificationLevel,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = security_classification_assignment)]
     #[holder(generate_deserialize)]
@@ -4686,7 +4685,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub assigned_security_classification: SecurityClassification,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum SecurityClassificationAssignmentAny {
@@ -4694,24 +4693,24 @@ pub mod explicit_draughting {
         # [holder (field = draughting_security_classification_assignment)]
         DraughtingSecurityClassificationAssignment(Box<DraughtingSecurityClassificationAssignment>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = security_classification_level)]
     #[holder(generate_deserialize)]
     pub struct SecurityClassificationLevel {
         pub name: Label,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = shape_definition_representation)]
     #[holder(generate_deserialize)]
     pub struct ShapeDefinitionRepresentation {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = shape_representation)]
     #[holder(generate_deserialize)]
     pub struct ShapeRepresentation {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum ShapeRepresentationAny {
@@ -4721,7 +4720,7 @@ pub mod explicit_draughting {
             Box<GeometricallyBounded2DWireframeRepresentation>,
         ),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = si_unit)]
     #[holder(generate_deserialize)]
@@ -4729,12 +4728,12 @@ pub mod explicit_draughting {
         pub prefix: Option<SiPrefix>,
         pub name: SiUnitName,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = structured_dimension_callout)]
     #[holder(generate_deserialize)]
     pub struct StructuredDimensionCallout {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = styled_item)]
     #[holder(generate_deserialize)]
@@ -4744,7 +4743,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub item: RepresentationItemAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum StyledItemAny {
@@ -4752,7 +4751,7 @@ pub mod explicit_draughting {
         # [holder (field = annotation_occurrence)]
         AnnotationOccurrence(Box<AnnotationOccurrence>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = symbol_colour)]
     #[holder(generate_deserialize)]
@@ -4760,12 +4759,12 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub colour_of_symbol: ColourAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = symbol_representation)]
     #[holder(generate_deserialize)]
     pub struct SymbolRepresentation {}
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum SymbolRepresentationAny {
@@ -4776,12 +4775,12 @@ pub mod explicit_draughting {
         # [holder (field = draughting_symbol_representation)]
         DraughtingSymbolRepresentation(Box<DraughtingSymbolRepresentation>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = symbol_representation_map)]
     #[holder(generate_deserialize)]
     pub struct SymbolRepresentationMap {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = symbol_style)]
     #[holder(generate_deserialize)]
@@ -4790,7 +4789,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub style_of_symbol: SymbolStyleSelect,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = symbol_target)]
     #[holder(generate_deserialize)]
@@ -4800,7 +4799,7 @@ pub mod explicit_draughting {
         pub x_scale: PositiveRatioMeasure,
         pub y_scale: PositiveRatioMeasure,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = terminator_symbol)]
     #[holder(generate_deserialize)]
@@ -4808,7 +4807,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub annotated_curve: AnnotationCurveOccurrenceAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum TerminatorSymbolAny {
@@ -4819,7 +4818,7 @@ pub mod explicit_draughting {
         # [holder (field = leader_terminator)]
         LeaderTerminator(Box<LeaderTerminator>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = text_literal)]
     #[holder(generate_deserialize)]
@@ -4832,7 +4831,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub font: FontSelect,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum TextLiteralAny {
@@ -4849,7 +4848,7 @@ pub mod explicit_draughting {
         # [holder (field = text_literal_with_extent)]
         TextLiteralWithExtent(Box<TextLiteralWithExtent>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = text_literal_with_associated_curves)]
     #[holder(generate_deserialize)]
@@ -4857,7 +4856,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub associated_curves: Vec<CurveAny>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = text_literal_with_blanking_box)]
     #[holder(generate_deserialize)]
@@ -4865,14 +4864,14 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub blanking: PlanarBox,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = text_literal_with_delineation)]
     #[holder(generate_deserialize)]
     pub struct TextLiteralWithDelineation {
         pub delineation: TextDelineation,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum TextLiteralWithDelineationAny {
@@ -4880,7 +4879,7 @@ pub mod explicit_draughting {
         # [holder (field = draughting_text_literal_with_delineation)]
         DraughtingTextLiteralWithDelineation(Box<DraughtingTextLiteralWithDelineation>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = text_literal_with_extent)]
     #[holder(generate_deserialize)]
@@ -4888,7 +4887,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub extent: PlanarExtentAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = text_style)]
     #[holder(generate_deserialize)]
@@ -4897,7 +4896,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub character_appearance: CharacterStyleSelect,
     }
-    #[derive(Debug, Clone, PartialEq, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, Holder)]
     # [holder (table = Tables)]
     #[holder(generate_deserialize)]
     pub enum TextStyleAny {
@@ -4908,7 +4907,7 @@ pub mod explicit_draughting {
         # [holder (field = text_style_with_mirror)]
         TextStyleWithMirror(Box<TextStyleWithMirror>),
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = text_style_for_defined_font)]
     #[holder(generate_deserialize)]
@@ -4916,7 +4915,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub text_colour: ColourAny,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = text_style_with_box_characteristics)]
     #[holder(generate_deserialize)]
@@ -4924,7 +4923,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub characteristics: Vec<BoxCharacteristicSelect>,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = text_style_with_mirror)]
     #[holder(generate_deserialize)]
@@ -4932,7 +4931,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub mirror_placement: Axis2Placement,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = trimmed_curve)]
     #[holder(generate_deserialize)]
@@ -4946,7 +4945,7 @@ pub mod explicit_draughting {
         pub sense_agreement: bool,
         pub master_representation: TrimmingPreference,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = two_direction_repeat_factor)]
     #[holder(generate_deserialize)]
@@ -4954,12 +4953,12 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub second_repeat_factor: Vector,
     }
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = uniform_curve)]
     #[holder(generate_deserialize)]
     pub struct UniformCurve {}
-    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, :: ruststep_derive :: Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
     # [holder (table = Tables)]
     # [holder (field = vector)]
     #[holder(generate_deserialize)]


### PR DESCRIPTION
Resolve #125, while this PR introduces `inline_express!` instead of `include_express!` macro. This is due to we cannot get full path where the proc-macro is called in stable way, although nightly API exists. See also Japanese article https://qiita.com/termoshtt/items/6a58ebeaded97a8cc7c6