### PR TITLE
Expose ruststep-derive macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 ## Unreleased (will be 0.2.0)
 
 ### Added
+- Expose `ruststep_derive::*` macros in `ruststep::` namespace https://github.com/ricosjp/ruststep/pull/159
 - Use rust-cache for faster CI https://github.com/ricosjp/ruststep/pull/156
 - Comprehensive tests for ruststep_derive https://github.com/ricosjp/ruststep/pull/147
 - Check CHANGELOG is updated in each pull request https://github.com/ricosjp/ruststep/pull/155
@@ -28,9 +29,11 @@ In addition to original Keep-a-Changelog, we use following rules:
 - Remove `ruststep_derive::as_holder_visitor!` https://github.com/ricosjp/ruststep/pull/147
 - Use Rust 2021 edition https://github.com/ricosjp/ruststep/pull/128
 
+### Fixed
+- Drop unused derive-new, derive_more, and dyn-clone crate dependencies https://github.com/ricosjp/ruststep/pull/159
+
 ### Deprecated
 ### Removed
-### Fixed
 ### Security
 
 ## 0.1.0 - 2021-09-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 - Use Rust 2021 edition https://github.com/ricosjp/ruststep/pull/128
 
 ### Fixed
-- Drop unused derive-new, derive_more, and dyn-clone crate dependencies https://github.com/ricosjp/ruststep/pull/159
+- Drop unused derive_more, and dyn-clone crate dependencies https://github.com/ricosjp/ruststep/pull/159
 
 ### Deprecated
 ### Removed

--- a/ruststep/Cargo.toml
+++ b/ruststep/Cargo.toml
@@ -18,9 +18,6 @@ default = []
 ap201 = []
 
 [dependencies]
-derive-new = "0.5.9"
-derive_more = "0.99.16"
-dyn-clone = "1.0.4"
 nom = "7.0.0"
 serde = { version = "1.0.129", features = ["derive"] }
 thiserror = "1.0.26"
@@ -29,7 +26,7 @@ itertools = "0.10.1"
 
 [dependencies.ruststep-derive]
 path = "../ruststep-derive"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [dev-dependencies]
 anyhow = "1.0.43"

--- a/ruststep/Cargo.toml
+++ b/ruststep/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 ap201 = []
 
 [dependencies]
+derive-new = "0.5.9"
 nom = "7.0.0"
 serde = { version = "1.0.129", features = ["derive"] }
 thiserror = "1.0.26"

--- a/ruststep/src/lib.rs
+++ b/ruststep/src/lib.rs
@@ -19,6 +19,8 @@ pub mod place_holder;
 pub mod primitive;
 pub mod tables;
 
+pub use ruststep_derive::*;
+
 // Automatically generated codes
 #[cfg(feature = "ap201")]
 pub mod ap201;


### PR DESCRIPTION
For #158 
Related to #123, but not expose `serde::Deserialize` because it collides to `ruststep_derive::Deserialize`