### PR TITLE
Refactoring espr/codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 - impl `FromStr` for `Record` and `DataSection` https://github.com/ricosjp/ruststep/pull/140
 
 ### Changed
+- Use `syn::Type` and other explicit types instead of `proc_macro2::TokenStream` in espr/codegen https://github.com/ricosjp/ruststep/pull/184
 - Cut out `IntoOwned` from `Holder` for compile `LIST OF LIST OF XXX`. https://github.com/ricosjp/ruststep/pull/183
 - Implement `AsRef` and `AsMut` in the case of multiple inheritance. https://github.com/ricosjp/ruststep/pull/179
 - Implements `AsRef`, `AsMut`, `Deref`, `DerefMut` for subtypes. https://github.com/ricosjp/ruststep/pull/174

--- a/espr/src/codegen/rust/entity.rs
+++ b/espr/src/codegen/rust/entity.rs
@@ -4,6 +4,34 @@ use check_keyword::CheckKeyword;
 use inflector::Inflector;
 use proc_macro2::TokenStream;
 use quote::*;
+use syn::parse_quote;
+
+// Each component of Rust struct corresponding to ENTITY in EXPRESS
+struct Field {
+    name: syn::Ident,
+    ty: syn::Type,
+    attributes: Vec<TokenStream>,
+}
+
+impl From<EntityAttribute> for Field {
+    fn from(attr: EntityAttribute) -> Self {
+        let EntityAttribute { name, ty, optional } = attr;
+
+        let name = format_ident!("{}", name.to_safe());
+        let ty = if optional {
+            parse_quote! { Option<#ty> }
+        } else {
+            parse_quote! { #ty }
+        };
+        let attributes = Vec::new();
+
+        Field {
+            name,
+            ty,
+            attributes,
+        }
+    }
+}
 
 impl ToTokens for EntityAttribute {
     fn to_tokens(&self, tokens: &mut TokenStream) {

--- a/espr/src/codegen/rust/entity.rs
+++ b/espr/src/codegen/rust/entity.rs
@@ -112,7 +112,7 @@ impl Entity {
         }
     }
 
-    fn supertype_attributes(&self) -> Vec<TokenStream> {
+    fn supertype_fields(&self) -> Vec<TokenStream> {
         let single_supertype = self.supertypes.len() == 1;
         self.supertypes
             .iter()
@@ -168,8 +168,13 @@ impl ToTokens for Entity {
         let name = self.name_ident();
         let field_name = self.field_ident();
 
-        let attributes = &self.attributes;
-        let supertype_attributes = self.supertype_attributes();
+        // Each component of struct is called "field" in Rust,
+        // and "attribute" refers other items
+        //
+        // https://doc.rust-lang.org/std/keyword.struct.html
+        let fields = &self.attributes;
+        let supertype_fields = self.supertype_fields();
+
         let derive = self.derives();
 
         tokens.append_all(quote! {
@@ -178,8 +183,8 @@ impl ToTokens for Entity {
             #[holder(field = #field_name)]
             #[holder(generate_deserialize)]
             pub struct #name {
-                #(#supertype_attributes,)*
-                #(#attributes,)*
+                #(#supertype_fields,)*
+                #(#fields,)*
             }
         });
 

--- a/espr/src/codegen/rust/entity.rs
+++ b/espr/src/codegen/rust/entity.rs
@@ -4,7 +4,6 @@ use check_keyword::CheckKeyword;
 use inflector::Inflector;
 use proc_macro2::TokenStream;
 use quote::*;
-use std::str::FromStr;
 
 impl ToTokens for EntityAttribute {
     fn to_tokens(&self, tokens: &mut TokenStream) {
@@ -144,21 +143,21 @@ impl Entity {
             .collect()
     }
 
-    fn derives(&self) -> Vec<TokenStream> {
+    fn derives(&self) -> Vec<syn::Path> {
         let mut derives = vec![
-            TokenStream::from_str("Debug").unwrap(),
-            TokenStream::from_str("Clone").unwrap(),
-            TokenStream::from_str("PartialEq").unwrap(),
-            TokenStream::from_str("::derive_new::new").unwrap(),
-            TokenStream::from_str("Holder").unwrap(),
+            syn::parse_str("Debug").unwrap(),
+            syn::parse_str("Clone").unwrap(),
+            syn::parse_str("PartialEq").unwrap(),
+            syn::parse_str("::derive_new::new").unwrap(),
+            syn::parse_str("Holder").unwrap(),
         ];
         if !self.supertypes.is_empty() {
-            derives.push(TokenStream::from_str("AsRef").unwrap());
-            derives.push(TokenStream::from_str("AsMut").unwrap());
+            derives.push(syn::parse_str("AsRef").unwrap());
+            derives.push(syn::parse_str("AsMut").unwrap());
         }
         if self.supertypes.len() == 1 {
-            derives.push(TokenStream::from_str("Deref").unwrap());
-            derives.push(TokenStream::from_str("DerefMut").unwrap());
+            derives.push(syn::parse_str("Deref").unwrap());
+            derives.push(syn::parse_str("DerefMut").unwrap());
         }
         derives
     }

--- a/espr/tests/any.rs
+++ b/espr/tests/any.rs
@@ -93,7 +93,7 @@ fn any() {
             }
         }
         #[derive(
-            Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+            Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
         )]
         # [holder (table = Tables)]
         # [holder (field = sub1)]
@@ -108,7 +108,7 @@ fn any() {
             pub y1: f64,
         }
         #[derive(
-            Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+            Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
         )]
         # [holder (table = Tables)]
         # [holder (field = sub2)]

--- a/espr/tests/subsuper.rs
+++ b/espr/tests/subsuper.rs
@@ -87,7 +87,7 @@ fn subsuper() {
             }
         }
         #[derive(
-            Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+            Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
         )]
         # [holder (table = Tables)]
         # [holder (field = sub)]
@@ -123,7 +123,7 @@ fn subsuper() {
             }
         }
         #[derive(
-            Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+            Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
         )]
         # [holder (table = Tables)]
         # [holder (field = subsub)]

--- a/ruststep/src/ap201.rs
+++ b/ruststep/src/ap201.rs
@@ -2810,7 +2810,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = angular_dimension)]
@@ -2824,7 +2824,7 @@ pub mod explicit_draughting {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = annotation_curve_occurrence)]
@@ -2875,7 +2875,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = annotation_fill_area)]
@@ -2891,7 +2891,7 @@ pub mod explicit_draughting {
         pub boundaries: Vec<CurveAny>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = annotation_fill_area_occurrence)]
@@ -2907,7 +2907,7 @@ pub mod explicit_draughting {
         pub fill_style_target: PointAny,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = annotation_occurrence)]
@@ -2974,7 +2974,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = annotation_subfigure_occurrence)]
@@ -2988,7 +2988,7 @@ pub mod explicit_draughting {
         pub annotation_symbol_occurrence: AnnotationSymbolOccurrence,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = annotation_symbol)]
@@ -3002,7 +3002,7 @@ pub mod explicit_draughting {
         pub mapped_item: MappedItem,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = annotation_symbol_occurrence)]
@@ -3045,7 +3045,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = annotation_text)]
@@ -3059,7 +3059,7 @@ pub mod explicit_draughting {
         pub mapped_item: MappedItem,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = annotation_text_occurrence)]
@@ -3234,7 +3234,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = axis2_placement_2d)]
@@ -3250,7 +3250,7 @@ pub mod explicit_draughting {
         pub ref_direction: Option<Direction>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = b_spline_curve)]
@@ -3323,7 +3323,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = b_spline_curve_with_knots)]
@@ -3340,7 +3340,7 @@ pub mod explicit_draughting {
         pub knot_spec: KnotType,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = bezier_curve)]
@@ -3354,7 +3354,7 @@ pub mod explicit_draughting {
         pub b_spline_curve: BSplineCurve,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = bounded_curve)]
@@ -3413,7 +3413,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = calendar_date)]
@@ -3429,7 +3429,7 @@ pub mod explicit_draughting {
         pub month_component: MonthInYearNumber,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = camera_image)]
@@ -3464,7 +3464,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = camera_image_2d_with_scale)]
@@ -3478,7 +3478,7 @@ pub mod explicit_draughting {
         pub camera_image: CameraImage,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = camera_model)]
@@ -3513,7 +3513,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = camera_model_d2)]
@@ -3530,7 +3530,7 @@ pub mod explicit_draughting {
         pub view_window_clipping: bool,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = camera_usage)]
@@ -3544,7 +3544,7 @@ pub mod explicit_draughting {
         pub representation_map: RepresentationMap,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = cartesian_point)]
@@ -3559,7 +3559,7 @@ pub mod explicit_draughting {
         pub coordinates: Vec<LengthMeasure>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = circle)]
@@ -3608,7 +3608,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = colour_rgb)]
@@ -3625,7 +3625,7 @@ pub mod explicit_draughting {
         pub blue: f64,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = colour_specification)]
@@ -3662,7 +3662,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = composite_curve)]
@@ -3689,7 +3689,7 @@ pub mod explicit_draughting {
         pub parent_curve: CurveAny,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = composite_text)]
@@ -3742,7 +3742,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = composite_text_with_associated_curves)]
@@ -3758,7 +3758,7 @@ pub mod explicit_draughting {
         pub associated_curves: Vec<CurveAny>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = composite_text_with_blanking_box)]
@@ -3774,7 +3774,7 @@ pub mod explicit_draughting {
         pub blanking: PlanarBox,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = composite_text_with_extent)]
@@ -3790,7 +3790,7 @@ pub mod explicit_draughting {
         pub extent: PlanarExtentAny,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = conic)]
@@ -3851,7 +3851,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = context_dependent_invisibility)]
@@ -3913,7 +3913,7 @@ pub mod explicit_draughting {
         pub description: Label,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = conversion_based_unit)]
@@ -3930,7 +3930,7 @@ pub mod explicit_draughting {
         pub conversion_factor: MeasureWithUnitAny,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = curve)]
@@ -3989,7 +3989,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = curve_dimension)]
@@ -4061,7 +4061,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = datum_feature_callout)]
@@ -4075,7 +4075,7 @@ pub mod explicit_draughting {
         pub draughting_callout: DraughtingCallout,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = datum_target_callout)]
@@ -4089,7 +4089,7 @@ pub mod explicit_draughting {
         pub draughting_callout: DraughtingCallout,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = defined_symbol)]
@@ -4107,7 +4107,7 @@ pub mod explicit_draughting {
         pub target: SymbolTarget,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = diameter_dimension)]
@@ -4121,7 +4121,7 @@ pub mod explicit_draughting {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = dimension_callout_component_relationship)]
@@ -4135,7 +4135,7 @@ pub mod explicit_draughting {
         pub draughting_callout_relationship: DraughtingCalloutRelationship,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = dimension_callout_relationship)]
@@ -4149,7 +4149,7 @@ pub mod explicit_draughting {
         pub draughting_callout_relationship: DraughtingCalloutRelationship,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = dimension_curve)]
@@ -4163,7 +4163,7 @@ pub mod explicit_draughting {
         pub annotation_curve_occurrence: AnnotationCurveOccurrence,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = dimension_curve_directed_callout)]
@@ -4230,7 +4230,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = dimension_curve_terminator)]
@@ -4245,7 +4245,7 @@ pub mod explicit_draughting {
         pub role: DimensionExtentUsage,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = dimension_pair)]
@@ -4272,7 +4272,7 @@ pub mod explicit_draughting {
         pub luminous_intensity_exponent: f64,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = direction)]
@@ -4335,7 +4335,7 @@ pub mod explicit_draughting {
         pub product_data_type: Label,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_annotation_occurrence)]
@@ -4349,7 +4349,7 @@ pub mod explicit_draughting {
         pub annotation_occurrence: AnnotationOccurrence,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_approval_assignment)]
@@ -4365,7 +4365,7 @@ pub mod explicit_draughting {
         pub approved_items: Vec<ApprovedItem>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_callout)]
@@ -4509,7 +4509,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_contract_assignment)]
@@ -4525,7 +4525,7 @@ pub mod explicit_draughting {
         pub items: Vec<ContractedItem>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_drawing_revision)]
@@ -4539,7 +4539,7 @@ pub mod explicit_draughting {
         pub drawing_revision: DrawingRevision,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_elements)]
@@ -4553,7 +4553,7 @@ pub mod explicit_draughting {
         pub draughting_callout: DraughtingCallout,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_group_assignment)]
@@ -4569,7 +4569,7 @@ pub mod explicit_draughting {
         pub items: Vec<DraughtingGroupedItem>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_model)]
@@ -4583,7 +4583,7 @@ pub mod explicit_draughting {
         pub representation: Representation,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_organization_assignment)]
@@ -4599,7 +4599,7 @@ pub mod explicit_draughting {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_person_and_organization_assignment)]
@@ -4615,7 +4615,7 @@ pub mod explicit_draughting {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_person_assignment)]
@@ -4631,7 +4631,7 @@ pub mod explicit_draughting {
         pub assigned_items: Vec<DraughtingOrganizationItem>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_pre_defined_colour)]
@@ -4645,7 +4645,7 @@ pub mod explicit_draughting {
         pub pre_defined_colour: PreDefinedColour,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_pre_defined_curve_font)]
@@ -4659,7 +4659,7 @@ pub mod explicit_draughting {
         pub pre_defined_curve_font: PreDefinedCurveFont,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_pre_defined_text_font)]
@@ -4673,7 +4673,7 @@ pub mod explicit_draughting {
         pub pre_defined_text_font: PreDefinedTextFont,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_presented_item)]
@@ -4689,7 +4689,7 @@ pub mod explicit_draughting {
         pub items: Vec<DraughtingPresentedItemSelect>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_security_classification_assignment)]
@@ -4705,7 +4705,7 @@ pub mod explicit_draughting {
         pub assigned_items: Vec<ClassifiedItem>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_specification_reference)]
@@ -4721,7 +4721,7 @@ pub mod explicit_draughting {
         pub specified_items: Vec<SpecifiedItem>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_subfigure_representation)]
@@ -4735,7 +4735,7 @@ pub mod explicit_draughting {
         pub symbol_representation: SymbolRepresentation,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_symbol_representation)]
@@ -4770,7 +4770,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = draughting_text_literal_with_delineation)]
@@ -4802,7 +4802,7 @@ pub mod explicit_draughting {
         pub drawing_type: Option<Label>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = drawing_revision)]
@@ -4841,7 +4841,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = drawing_sheet_layout)]
@@ -4855,7 +4855,7 @@ pub mod explicit_draughting {
         pub draughting_symbol_representation: DraughtingSymbolRepresentation,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = drawing_sheet_revision)]
@@ -4870,7 +4870,7 @@ pub mod explicit_draughting {
         pub revision_identifier: Identifier,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = drawing_sheet_revision_usage)]
@@ -4885,7 +4885,7 @@ pub mod explicit_draughting {
         pub sheet_number: Identifier,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = ellipse)]
@@ -4909,7 +4909,7 @@ pub mod explicit_draughting {
         pub source_id: SourceItem,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = externally_defined_curve_font)]
@@ -4922,7 +4922,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub externally_defined_item: ExternallyDefinedItem,
     }
-    #[derive(Debug, Clone, PartialEq, AsRef, AsMut, :: derive_new :: new, Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut)]
     # [holder (table = Tables)]
     # [holder (field = externally_defined_hatch_style)]
     #[holder(generate_deserialize)]
@@ -5000,7 +5000,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = externally_defined_symbol)]
@@ -5014,7 +5014,7 @@ pub mod explicit_draughting {
         pub externally_defined_item: ExternallyDefinedItem,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = externally_defined_text_font)]
@@ -5027,7 +5027,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub externally_defined_item: ExternallyDefinedItem,
     }
-    #[derive(Debug, Clone, PartialEq, AsRef, AsMut, :: derive_new :: new, Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut)]
     # [holder (table = Tables)]
     # [holder (field = externally_defined_tile_style)]
     #[holder(generate_deserialize)]
@@ -5060,7 +5060,7 @@ pub mod explicit_draughting {
         pub fill_colour: ColourAny,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = fill_area_style_hatching)]
@@ -5083,7 +5083,7 @@ pub mod explicit_draughting {
         pub hatch_line_angle: PlaneAngleMeasure,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = fill_area_style_tile_symbol_with_style)]
@@ -5099,7 +5099,7 @@ pub mod explicit_draughting {
         pub symbol: AnnotationSymbolOccurrenceAny,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = fill_area_style_tiles)]
@@ -5118,7 +5118,7 @@ pub mod explicit_draughting {
         pub tiling_scale: PositiveRatioMeasure,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = geometric_curve_set)]
@@ -5132,7 +5132,7 @@ pub mod explicit_draughting {
         pub geometric_set: GeometricSet,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = geometric_representation_context)]
@@ -5147,7 +5147,7 @@ pub mod explicit_draughting {
         pub coordinate_space_dimension: DimensionCount,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = geometric_representation_item)]
@@ -5334,7 +5334,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = geometric_set)]
@@ -5371,7 +5371,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = geometrical_tolerance_callout)]
@@ -5385,7 +5385,7 @@ pub mod explicit_draughting {
         pub draughting_callout: DraughtingCallout,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = geometrically_bounded_2d_wireframe_representation)]
@@ -5399,7 +5399,7 @@ pub mod explicit_draughting {
         pub shape_representation: ShapeRepresentation,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = global_unit_assigned_context)]
@@ -5464,7 +5464,7 @@ pub mod explicit_draughting {
         pub related_group: Group,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = hyperbola)]
@@ -5509,7 +5509,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = leader_curve)]
@@ -5523,7 +5523,7 @@ pub mod explicit_draughting {
         pub annotation_curve_occurrence: AnnotationCurveOccurrence,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = leader_directed_callout)]
@@ -5558,7 +5558,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = leader_directed_dimension)]
@@ -5572,7 +5572,7 @@ pub mod explicit_draughting {
         pub leader_directed_callout: LeaderDirectedCallout,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = leader_terminator)]
@@ -5586,7 +5586,7 @@ pub mod explicit_draughting {
         pub terminator_symbol: TerminatorSymbol,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = length_measure_with_unit)]
@@ -5600,7 +5600,7 @@ pub mod explicit_draughting {
         pub measure_with_unit: MeasureWithUnit,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = length_unit)]
@@ -5614,7 +5614,7 @@ pub mod explicit_draughting {
         pub named_unit: NamedUnit,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = line)]
@@ -5632,7 +5632,7 @@ pub mod explicit_draughting {
         pub dir: Vector,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = linear_dimension)]
@@ -5646,7 +5646,7 @@ pub mod explicit_draughting {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = mapped_item)]
@@ -5793,7 +5793,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = offset_curve_2d)]
@@ -5811,7 +5811,7 @@ pub mod explicit_draughting {
         pub self_intersect: Logical,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = one_direction_repeat_factor)]
@@ -5848,7 +5848,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = ordinate_dimension)]
@@ -5909,7 +5909,7 @@ pub mod explicit_draughting {
         pub name: Label,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = organizational_address)]
@@ -5926,7 +5926,7 @@ pub mod explicit_draughting {
         pub description: Text,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = parabola)]
@@ -6041,7 +6041,7 @@ pub mod explicit_draughting {
         pub name: Label,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = personal_address)]
@@ -6058,7 +6058,7 @@ pub mod explicit_draughting {
         pub description: Text,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = placement)]
@@ -6095,7 +6095,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = planar_box)]
@@ -6111,7 +6111,7 @@ pub mod explicit_draughting {
         pub placement: Axis2Placement,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = planar_extent)]
@@ -6148,7 +6148,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = plane_angle_measure_with_unit)]
@@ -6162,7 +6162,7 @@ pub mod explicit_draughting {
         pub measure_with_unit: MeasureWithUnit,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = plane_angle_unit)]
@@ -6176,7 +6176,7 @@ pub mod explicit_draughting {
         pub named_unit: NamedUnit,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = point)]
@@ -6219,7 +6219,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = point_on_curve)]
@@ -6236,7 +6236,7 @@ pub mod explicit_draughting {
         pub point_parameter: ParameterValue,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = polyline)]
@@ -6251,7 +6251,7 @@ pub mod explicit_draughting {
         #[holder(use_place_holder)]
         pub points: Vec<CartesianPoint>,
     }
-    #[derive(Debug, Clone, PartialEq, AsRef, AsMut, :: derive_new :: new, Holder)]
+    #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut)]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_colour)]
     #[holder(generate_deserialize)]
@@ -6287,7 +6287,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_curve_font)]
@@ -6322,7 +6322,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_dimension_symbol)]
@@ -6336,7 +6336,7 @@ pub mod explicit_draughting {
         pub pre_defined_symbol: PreDefinedSymbol,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_geometrical_tolerance_symbol)]
@@ -6402,7 +6402,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_point_marker_symbol)]
@@ -6416,7 +6416,7 @@ pub mod explicit_draughting {
         pub pre_defined_symbol: PreDefinedSymbol,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_symbol)]
@@ -6475,7 +6475,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_terminator_symbol)]
@@ -6489,7 +6489,7 @@ pub mod explicit_draughting {
         pub pre_defined_symbol: PreDefinedSymbol,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = pre_defined_text_font)]
@@ -6524,7 +6524,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = presentation_area)]
@@ -6579,7 +6579,7 @@ pub mod explicit_draughting {
         pub presentation: PresentationRepresentationAny,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = presentation_representation)]
@@ -6687,7 +6687,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = presentation_style_by_context)]
@@ -6703,7 +6703,7 @@ pub mod explicit_draughting {
         pub style_context: StyleContextSelect,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = presentation_view)]
@@ -6764,7 +6764,7 @@ pub mod explicit_draughting {
         pub frame_of_reference: Vec<ProductContext>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = product_context)]
@@ -6791,7 +6791,7 @@ pub mod explicit_draughting {
         pub frame_of_reference: ProductDefinitionContext,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = product_definition_context)]
@@ -6816,7 +6816,7 @@ pub mod explicit_draughting {
         pub of_product: Product,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = product_definition_shape)]
@@ -6830,7 +6830,7 @@ pub mod explicit_draughting {
         pub property_definition: PropertyDefinition,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = projection_curve)]
@@ -6844,7 +6844,7 @@ pub mod explicit_draughting {
         pub annotation_curve_occurrence: AnnotationCurveOccurrence,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = projection_directed_callout)]
@@ -6943,7 +6943,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = quasi_uniform_curve)]
@@ -6957,7 +6957,7 @@ pub mod explicit_draughting {
         pub b_spline_curve: BSplineCurve,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = radius_dimension)]
@@ -6971,7 +6971,7 @@ pub mod explicit_draughting {
         pub dimension_curve_directed_callout: DimensionCurveDirectedCallout,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = rational_b_spline_curve)]
@@ -7210,7 +7210,7 @@ pub mod explicit_draughting {
         pub name: Label,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = shape_definition_representation)]
@@ -7224,7 +7224,7 @@ pub mod explicit_draughting {
         pub property_definition_representation: PropertyDefinitionRepresentation,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = shape_representation)]
@@ -7263,7 +7263,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = si_unit)]
@@ -7279,7 +7279,7 @@ pub mod explicit_draughting {
         pub name: SiUnitName,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = structured_dimension_callout)]
@@ -7293,7 +7293,7 @@ pub mod explicit_draughting {
         pub draughting_callout: DraughtingCallout,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = styled_item)]
@@ -7340,7 +7340,7 @@ pub mod explicit_draughting {
         pub colour_of_symbol: ColourAny,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = symbol_representation)]
@@ -7383,7 +7383,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = symbol_representation_map)]
@@ -7406,7 +7406,7 @@ pub mod explicit_draughting {
         pub style_of_symbol: SymbolStyleSelect,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = symbol_target)]
@@ -7424,7 +7424,7 @@ pub mod explicit_draughting {
         pub y_scale: PositiveRatioMeasure,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = terminator_symbol)]
@@ -7469,7 +7469,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = text_literal)]
@@ -7535,7 +7535,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = text_literal_with_associated_curves)]
@@ -7551,7 +7551,7 @@ pub mod explicit_draughting {
         pub associated_curves: Vec<CurveAny>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = text_literal_with_blanking_box)]
@@ -7567,7 +7567,7 @@ pub mod explicit_draughting {
         pub blanking: PlanarBox,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = text_literal_with_delineation)]
@@ -7605,7 +7605,7 @@ pub mod explicit_draughting {
         }
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = text_literal_with_extent)]
@@ -7667,7 +7667,7 @@ pub mod explicit_draughting {
         pub text_colour: ColourAny,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = text_style_with_box_characteristics)]
@@ -7683,7 +7683,7 @@ pub mod explicit_draughting {
         pub characteristics: Vec<BoxCharacteristicSelect>,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = text_style_with_mirror)]
@@ -7699,7 +7699,7 @@ pub mod explicit_draughting {
         pub mirror_placement: Axis2Placement,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = trimmed_curve)]
@@ -7721,7 +7721,7 @@ pub mod explicit_draughting {
         pub master_representation: TrimmingPreference,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = two_direction_repeat_factor)]
@@ -7737,7 +7737,7 @@ pub mod explicit_draughting {
         pub second_repeat_factor: Vector,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = uniform_curve)]
@@ -7751,7 +7751,7 @@ pub mod explicit_draughting {
         pub b_spline_curve: BSplineCurve,
     }
     #[derive(
-        Debug, Clone, PartialEq, AsRef, AsMut, Deref, DerefMut, :: derive_new :: new, Holder,
+        Debug, Clone, PartialEq, :: derive_new :: new, Holder, AsRef, AsMut, Deref, DerefMut,
     )]
     # [holder (table = Tables)]
     # [holder (field = vector)]


### PR DESCRIPTION
- Add `espr::codegen::rust::Field` struct instead of `espr::ir::EntityAttribute`
- Use `syn::Type` and other explicit types instead of `proc_macro2::TokenStream`