### PR TITLE
Drop type parameter `T` in `SingleMapDeserializer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 ## Unreleased (will be 0.2.0)
 
 ### Added
+- Drop type parameter T in SingleMapDeserializer https://github.com/ricosjp/ruststep/pull/191
 - Add the module created from AP203. https://github.com/ricosjp/ruststep/pull/185
 - Legalize the type declare of `SET` and `LIST`. https://github.com/ricosjp/ruststep/pull/171
 - Snapshot testing for ruststep-derive https://github.com/ricosjp/ruststep/pull/175

--- a/ruststep/src/ast/parameter.rs
+++ b/ruststep/src/ast/parameter.rs
@@ -157,7 +157,7 @@ impl<'de, 'param> de::Deserializer<'de> for &'param Parameter {
     {
         match self {
             Parameter::Typed { name, ty } => {
-                visitor.visit_map(SingleMapDeserializer::new(name, ty.as_ref()))
+                visitor.visit_map(SingleMapDeserializer::new(name, *ty.clone()))
             }
             Parameter::Integer(val) => visitor.visit_i64(*val),
             Parameter::Real(val) => visitor.visit_f64(*val),

--- a/ruststep/src/ast/record.rs
+++ b/ruststep/src/ast/record.rs
@@ -32,7 +32,7 @@ impl<'de, 'record> de::Deserializer<'de> for &'record Record {
     {
         visitor.visit_map(SingleMapDeserializer::new(
             &self.name,
-            self.parameters.iter().collect::<Vec<&Parameter>>(),
+            self.parameters.iter().collect::<Parameter>(),
         ))
     }
 

--- a/ruststep/src/ast/single_map_deserializer.rs
+++ b/ruststep/src/ast/single_map_deserializer.rs
@@ -1,14 +1,15 @@
+use super::parameter::Parameter;
 use serde::de::{self, IntoDeserializer};
 
 /// Deserializer corresponding to a single-key map like `{ "A": [1.0, 2.0] }`
 #[derive(Debug)]
-pub struct SingleMapDeserializer<T> {
+pub struct SingleMapDeserializer {
     key: Option<String>,
-    value: Option<T>,
+    value: Option<Parameter>,
 }
 
-impl<T> SingleMapDeserializer<T> {
-    pub fn new(key: &str, value: T) -> Self {
+impl SingleMapDeserializer {
+    pub fn new(key: &str, value: Parameter) -> Self {
         SingleMapDeserializer {
             key: Some(key.to_string()),
             value: Some(value),
@@ -17,10 +18,7 @@ impl<T> SingleMapDeserializer<T> {
 }
 
 // Entry point of `visit_map`
-impl<'de, T> de::MapAccess<'de> for SingleMapDeserializer<T>
-where
-    T: IntoDeserializer<'de, crate::error::Error>,
-{
+impl<'de> de::MapAccess<'de> for SingleMapDeserializer {
     type Error = crate::error::Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
@@ -51,10 +49,7 @@ where
 }
 
 // Entry point of `visit_enum`
-impl<'de, T> de::EnumAccess<'de> for SingleMapDeserializer<T>
-where
-    T: IntoDeserializer<'de, crate::error::Error>,
-{
+impl<'de> de::EnumAccess<'de> for SingleMapDeserializer {
     type Error = crate::error::Error;
     type Variant = Self; // this requires `VariantAccess` (see below impl)
 
@@ -86,10 +81,7 @@ where
 // But, `SingleMapDeserializer` is only used for "newtype_variant" case,
 // and returns `Err` in other cases.
 //
-impl<'de, T> de::VariantAccess<'de> for SingleMapDeserializer<T>
-where
-    T: IntoDeserializer<'de, crate::error::Error>,
-{
+impl<'de> de::VariantAccess<'de> for SingleMapDeserializer {
     type Error = crate::error::Error;
 
     fn unit_variant(self) -> Result<(), Self::Error> {

--- a/ruststep/src/ast/single_map_deserializer.rs
+++ b/ruststep/src/ast/single_map_deserializer.rs
@@ -39,8 +39,7 @@ impl<'de> de::MapAccess<'de> for SingleMapDeserializer {
         V: de::DeserializeSeed<'de>,
     {
         if let Some(value) = self.value.take() {
-            let value = value.into_deserializer();
-            let value: V::Value = seed.deserialize(value)?;
+            let value: V::Value = seed.deserialize(&value)?;
             Ok(value)
         } else {
             unreachable!("next_value_seed before next_key_seed is incorrect.")

--- a/ruststep/src/ast/value.rs
+++ b/ruststep/src/ast/value.rs
@@ -1,4 +1,4 @@
-use super::SingleMapDeserializer;
+use super::{parameter::Parameter, SingleMapDeserializer};
 use serde::{de, forward_to_deserialize_any, Deserialize};
 
 #[cfg(doc)] // for doc-link
@@ -34,14 +34,22 @@ impl<'de, 'value> de::Deserializer<'de> for &'value RValue {
         V: de::Visitor<'de>,
     {
         match self {
-            RValue::Entity(id) => visitor.visit_enum(SingleMapDeserializer::new("Entity", *id)),
-            RValue::Value(id) => visitor.visit_enum(SingleMapDeserializer::new("Value", *id)),
-            RValue::ConstantEntity(name) => {
-                visitor.visit_enum(SingleMapDeserializer::new("ConstantEntity", name.clone()))
-            }
-            RValue::ConstantValue(name) => {
-                visitor.visit_enum(SingleMapDeserializer::new("ConstantValue", name.clone()))
-            }
+            RValue::Entity(id) => visitor.visit_enum(SingleMapDeserializer::new(
+                "Entity",
+                Parameter::Integer(*id as i64),
+            )),
+            RValue::Value(id) => visitor.visit_enum(SingleMapDeserializer::new(
+                "Value",
+                Parameter::Integer(*id as i64),
+            )),
+            RValue::ConstantEntity(name) => visitor.visit_enum(SingleMapDeserializer::new(
+                "ConstantEntity",
+                Parameter::String(name.clone()),
+            )),
+            RValue::ConstantValue(name) => visitor.visit_enum(SingleMapDeserializer::new(
+                "ConstantValue",
+                Parameter::String(name.clone()),
+            )),
         }
     }
 


### PR DESCRIPTION
Split from #131 

`T` can be represented by `Parameter` dynamically.