### PR TITLE
Revise serde mapping of ruststep::ast

### DIFF
--- a/ruststep-derive/src/table_init.rs
+++ b/ruststep-derive/src/table_init.rs
@@ -40,13 +40,13 @@ fn entity_impl_table_init(ident: &syn::Ident, st: &syn::DataStruct) -> TokenStre
                 use #ruststep::{error::Error, tables::insert_record, ast::EntityInstance};
                 for entity in &data_sec.entities {
                     match entity {
-                        EntityInstance::Simple { id, record } => match record.keyword.as_str() {
+                        EntityInstance::Simple { id, instance } => match instance.keyword.as_str() {
                             #(
-                            #entity_names => insert_record(&mut self.#table_names, *id, record)?,
+                            #entity_names => insert_record(&mut self.#table_names, *id, instance)?,
                             )*
                             _ => {
                                 return Err(Error::UnknownEntityName {
-                                    entity_name: record.keyword.clone(),
+                                    entity_name: instance.keyword.clone(),
                                     schema: "".to_string(),
                                 });
                             }
@@ -95,13 +95,13 @@ fn tuple_impl_table_init(ident: &syn::Ident, st: &syn::DataStruct) -> TokenStrea
                 use #ruststep::{error::Error, tables::insert_record, ast::EntityInstance};
                 for entity in &data_sec.entities {
                     match entity {
-                        EntityInstance::Simple { id, record } => match record.name.as_str() {
+                        EntityInstance::Simple { id, instance } => match instance.name.as_str() {
                             #(
-                            #entity_names => insert_record(&mut self.#table_names, *id, record)?,
+                            #entity_names => insert_record(&mut self.#table_names, *id, instance)?,
                             )*
                             _ => {
                                 return Err(Error::UnknownEntityName {
-                                    entity_name: record.name.clone(),
+                                    entity_name: instance.name.clone(),
                                     schema: "".to_string(),
                                 });
                             }

--- a/ruststep-derive/src/table_init.rs
+++ b/ruststep-derive/src/table_init.rs
@@ -22,9 +22,9 @@ fn entity_impl_table_init(ident: &syn::Ident, st: &syn::DataStruct) -> TokenStre
     let mut entity_names = Vec::new();
     for field in &st.fields {
         let ident = field.ident.as_ref().expect_or_abort("unreachable!");
-        let name = ident.to_string().to_screaming_snake_case();
+        let keyword = ident.to_string().to_screaming_snake_case();
         table_names.push(ident);
-        entity_names.push(name);
+        entity_names.push(keyword);
     }
     assert_eq!(table_names.len(), entity_names.len());
 
@@ -40,13 +40,13 @@ fn entity_impl_table_init(ident: &syn::Ident, st: &syn::DataStruct) -> TokenStre
                 use #ruststep::{error::Error, tables::insert_record, ast::EntityInstance};
                 for entity in &data_sec.entities {
                     match entity {
-                        EntityInstance::Simple { id, record } => match record.name.as_str() {
+                        EntityInstance::Simple { id, record } => match record.keyword.as_str() {
                             #(
                             #entity_names => insert_record(&mut self.#table_names, *id, record)?,
                             )*
                             _ => {
                                 return Err(Error::UnknownEntityName {
-                                    entity_name: record.name.clone(),
+                                    entity_name: record.keyword.clone(),
                                     schema: "".to_string(),
                                 });
                             }

--- a/ruststep/src/ast/de/deserializer.rs
+++ b/ruststep/src/ast/de/deserializer.rs
@@ -41,7 +41,7 @@ impl<'de> de::SeqAccess<'de> for SeqDeserializer {
 #[derive(Debug)]
 pub struct RecordDeserializer {
     key: Option<String>,
-    value: Option<Parameter>,
+    value: Parameter,
 }
 
 impl<'de, 'record> de::IntoDeserializer<'de, crate::error::Error> for &'record Record {
@@ -49,7 +49,7 @@ impl<'de, 'record> de::IntoDeserializer<'de, crate::error::Error> for &'record R
     fn into_deserializer(self) -> RecordDeserializer {
         RecordDeserializer {
             key: Some(self.name.to_string()),
-            value: Some(*self.parameter.clone()),
+            value: *self.parameter.clone(),
         }
     }
 }
@@ -75,7 +75,7 @@ impl RecordDeserializer {
     pub fn new(key: &str, value: Parameter) -> Self {
         RecordDeserializer {
             key: Some(key.to_string()),
-            value: Some(value),
+            value: value,
         }
     }
 }
@@ -101,12 +101,8 @@ impl<'de> de::MapAccess<'de> for RecordDeserializer {
     where
         V: de::DeserializeSeed<'de>,
     {
-        if let Some(value) = self.value.take() {
-            let value: V::Value = seed.deserialize(&value)?;
-            Ok(value)
-        } else {
-            unreachable!("next_value_seed before next_key_seed is incorrect.")
-        }
+        let value: V::Value = seed.deserialize(&self.value)?;
+        Ok(value)
     }
 }
 

--- a/ruststep/src/ast/de/deserializer.rs
+++ b/ruststep/src/ast/de/deserializer.rs
@@ -50,7 +50,7 @@ impl<'de, 'record> de::IntoDeserializer<'de, crate::error::Error>
     type Deserializer = RecordDeserializer;
     fn into_deserializer(self) -> RecordDeserializer {
         RecordDeserializer {
-            key: Some(self.name.to_string()),
+            key: Some(self.keyword.to_string()),
             value: self.parameters.iter().collect(),
         }
     }

--- a/ruststep/src/ast/de/deserializer.rs
+++ b/ruststep/src/ast/de/deserializer.rs
@@ -51,7 +51,7 @@ impl<'de, 'record> de::IntoDeserializer<'de, crate::error::Error>
     fn into_deserializer(self) -> RecordDeserializer {
         RecordDeserializer {
             key: Some(self.name.to_string()),
-            value: *self.parameter.clone(),
+            value: self.parameters.iter().collect(),
         }
     }
 }

--- a/ruststep/src/ast/de/deserializer.rs
+++ b/ruststep/src/ast/de/deserializer.rs
@@ -44,7 +44,9 @@ pub struct RecordDeserializer {
     value: Parameter,
 }
 
-impl<'de, 'record> de::IntoDeserializer<'de, crate::error::Error> for &'record SimpleEntityInstance {
+impl<'de, 'record> de::IntoDeserializer<'de, crate::error::Error>
+    for &'record SimpleEntityInstance
+{
     type Deserializer = RecordDeserializer;
     fn into_deserializer(self) -> RecordDeserializer {
         RecordDeserializer {

--- a/ruststep/src/ast/de/deserializer.rs
+++ b/ruststep/src/ast/de/deserializer.rs
@@ -44,7 +44,7 @@ pub struct RecordDeserializer {
     value: Parameter,
 }
 
-impl<'de, 'record> de::IntoDeserializer<'de, crate::error::Error> for &'record Record {
+impl<'de, 'record> de::IntoDeserializer<'de, crate::error::Error> for &'record SimpleEntityInstance {
     type Deserializer = RecordDeserializer;
     fn into_deserializer(self) -> RecordDeserializer {
         RecordDeserializer {

--- a/ruststep/src/ast/de/deserializer.rs
+++ b/ruststep/src/ast/de/deserializer.rs
@@ -110,59 +110,66 @@ impl<'de> de::MapAccess<'de> for RecordDeserializer {
     }
 }
 
-// Entry point of `visit_enum`
-impl<'de> de::EnumAccess<'de> for RecordDeserializer {
-    type Error = crate::error::Error;
-    type Variant = Self; // this requires `VariantAccess` (see below impl)
-
-    fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant)>
-    where
-        V: de::DeserializeSeed<'de>,
-    {
-        match de::MapAccess::next_key_seed(&mut self, seed)? {
-            Some(key) => Ok((key, self)),
-            None => Err(de::Error::invalid_type(de::Unexpected::Map, &"enum")),
-        }
-    }
-}
-
-// As serde document says,
+// Note for understanding serde enum types
+// ----------------------------------------
 //
-// https://docs.serde.rs/serde/de/trait.VariantAccess.html
-//
-// > VariantAccess is a visitor that is created by the Deserializer
-// > and passed to the Deserialize to deserialize the content of a particular enum variant.
-//
-// this trait is used for 4 data models:
+// In serde impl, we have to implement `VariantAccess` and `EnumAccess`
+// since `Visitor::visit_enum` requires `EnumAccess` and it requires `VariantAccess`.
+// `VariantAccess` and `EnumAccess` traits are used for 4 data models:
 //
 // - "unit_variant"    e.g. the `E::A` and `E::B` in `enum E { A, B }`
 // - "newtype_variant" e.g. the `E::N` in `enum E { N(u8) }`
 // - "tuple_variant"   e.g. the `E::T` in `enum E { T(u8, u8) }`
 // - "struct_variant"  e.g. the `E::S` in `enum E { S { r: u8, g: u8, b: u8 } }`
 //
-// But, `RecordDeserializer` is only used for "newtype_variant" case,
-// and returns `Err` in other cases.
+// Roughly, `EnumAccess` determines which variant are used e.g. `E::N` in above "newtype_variant" case,
+// and `VariantAccess` determines its component e.g. `1u8`.
+// These are composed into `E::N(1u8)` in `Visitor::visit_enum`.
 //
-impl<'de> de::VariantAccess<'de> for RecordDeserializer {
+impl<'de, 'name> de::EnumAccess<'de> for &'name Name {
+    type Error = crate::error::Error;
+    type Variant = Self;
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let key: de::value::StrDeserializer<Self::Error> = match self {
+            Name::Entity(_) => "Entity",
+            Name::Value(_) => "Value",
+            Name::ConstantEntity(_) => "ConstantEntity",
+            Name::ConstantValue(_) => "ConstantValue",
+        }
+        .into_deserializer();
+        let key: V::Value = seed.deserialize(key)?;
+        Ok((key, self))
+    }
+}
+
+impl<'de, 'name> de::VariantAccess<'de> for &'name Name {
     type Error = crate::error::Error;
 
     fn unit_variant(self) -> Result<()> {
-        let unexp = de::Unexpected::Map;
+        let unexp = de::Unexpected::NewtypeVariant;
         Err(de::Error::invalid_type(unexp, &"unit variant"))
     }
 
-    fn newtype_variant_seed<D>(mut self, seed: D) -> Result<D::Value>
+    fn newtype_variant_seed<D>(self, seed: D) -> Result<D::Value>
     where
         D: de::DeserializeSeed<'de>,
     {
-        de::MapAccess::next_value_seed(&mut self, seed)
+        match self {
+            Name::Entity(id) | Name::Value(id) => seed.deserialize(id.into_deserializer()),
+            Name::ConstantEntity(name) | Name::ConstantValue(name) => {
+                seed.deserialize(name.as_str().into_deserializer())
+            }
+        }
     }
 
     fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
-        let unexp = de::Unexpected::Map;
+        let unexp = de::Unexpected::NewtypeVariant;
         Err(de::Error::invalid_type(unexp, &"tuple variant"))
     }
 
@@ -170,7 +177,7 @@ impl<'de> de::VariantAccess<'de> for RecordDeserializer {
     where
         V: de::Visitor<'de>,
     {
-        let unexp = de::Unexpected::Map;
+        let unexp = de::Unexpected::NewtypeVariant;
         Err(de::Error::invalid_type(unexp, &"struct variant"))
     }
 }

--- a/ruststep/src/ast/de/mod.rs
+++ b/ruststep/src/ast/de/mod.rs
@@ -23,7 +23,7 @@
 //! | Omitted     | option (always none)|
 //! | Enumeration | unit_variant (through [serde::de::value::StringDeserializer])|
 //! | Typed       | map (through [RecordDeserializer])|
-//! | Ref         | newtype_variant (through [RecordDeserializer])|
+//! | Ref         | newtype_variant  |
 //!
 //! Be sure that this mapping is not only for espr-generated structs.
 //! This can be used with other Rust structs using `serde_derive::Deserialize` custom derive:

--- a/ruststep/src/ast/de/mod.rs
+++ b/ruststep/src/ast/de/mod.rs
@@ -8,9 +8,9 @@
 //! > into [Serde's data model](https://serde.rs/data-model.html) by invoking exactly one of the methods
 //! > on the Visitor that it receives.
 //!
-//! [serde::de::Deserializer] trait is implemented for [Parameter] and [Record].
+//! [serde::de::Deserializer] trait is implemented for [Parameter] and [SimpleEntityInstance].
 //!
-//! - [Record] is mapped to `map` in serde data model through [RecordDeserializer],
+//! - [SimpleEntityInstance] is mapped to `map` in serde data model through [RecordDeserializer],
 //! - [Parameter] is mapped as following table:
 //!
 //! | Parameter   | serde data model |

--- a/ruststep/src/ast/de/parameter.rs
+++ b/ruststep/src/ast/de/parameter.rs
@@ -31,7 +31,9 @@ impl<'de, 'param> de::Deserializer<'de> for &'param Parameter {
         V: de::Visitor<'de>,
     {
         match self {
-            Parameter::Typed(record) => de::Deserializer::deserialize_any(record, visitor),
+            Parameter::Typed { keyword, parameter } => {
+                visitor.visit_map(RecordDeserializer::new(keyword, *parameter.clone()))
+            }
             Parameter::Integer(val) => visitor.visit_i64(*val),
             Parameter::Real(val) => visitor.visit_f64(*val),
             Parameter::String(val) => visitor.visit_str(val),

--- a/ruststep/src/ast/de/parameter.rs
+++ b/ruststep/src/ast/de/parameter.rs
@@ -36,7 +36,7 @@ impl<'de, 'param> de::Deserializer<'de> for &'param Parameter {
             Parameter::Real(val) => visitor.visit_f64(*val),
             Parameter::String(val) => visitor.visit_str(val),
             Parameter::List(params) => visitor.visit_seq(SeqDeserializer::new(params)),
-            Parameter::Ref(name) => visitor.visit_enum(name_to_reserializer(name.clone())),
+            Parameter::Ref(name) => visitor.visit_enum(name),
             Parameter::NotProvided | Parameter::Omitted => visitor.visit_none(),
             Parameter::Enumeration(variant) => {
                 visitor.visit_enum(variant.to_class_case().into_deserializer())
@@ -48,18 +48,5 @@ impl<'de, 'param> de::Deserializer<'de> for &'param Parameter {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         struct tuple_struct map enum identifier ignored_any
-    }
-}
-
-fn name_to_reserializer(name: Name) -> RecordDeserializer {
-    match name {
-        Name::Entity(id) => RecordDeserializer::new("Entity", Parameter::Integer(id as i64)),
-        Name::Value(id) => RecordDeserializer::new("Value", Parameter::Integer(id as i64)),
-        Name::ConstantEntity(name) => {
-            RecordDeserializer::new("ConstantEntity", Parameter::String(name))
-        }
-        Name::ConstantValue(name) => {
-            RecordDeserializer::new("ConstantValue", Parameter::String(name))
-        }
     }
 }

--- a/ruststep/src/ast/de/parameter.rs
+++ b/ruststep/src/ast/de/parameter.rs
@@ -6,7 +6,7 @@ use serde::{
     forward_to_deserialize_any,
 };
 
-impl<'de, 'record> de::Deserializer<'de> for &'record Record {
+impl<'de, 'record> de::Deserializer<'de> for &'record SimpleEntityInstance {
     type Error = crate::error::Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/ruststep/src/ast/mod.rs
+++ b/ruststep/src/ast/mod.rs
@@ -118,16 +118,16 @@ derive_ast_from_str!(DataSection, parser::exchange::data_section);
 /// assert_eq!(residual, "");
 ///
 /// // A((2.0, 3.0))
-/// let a = Parameter::Typed(SimpleEntityInstance {
-///     name: "A".to_string(),
+/// let a = Parameter::Typed {
+///     keyword: "A".to_string(),
 ///     parameter: Box::new(vec![Parameter::real(2.0), Parameter::real(3.0)].into()),
-/// });
+/// };
 ///
 /// // B((1.0, a))
-/// let b = Parameter::Typed(SimpleEntityInstance {
-///     name: "B".to_string(),
+/// let b = Parameter::Typed {
+///     keyword: "B".to_string(),
 ///     parameter: Box::new(vec![Parameter::real(1.0), a].into()),
-/// });
+/// };
 ///
 /// assert_eq!(p, b);
 /// ```
@@ -165,9 +165,12 @@ pub enum Parameter {
     /// # use std::str::FromStr;
     /// # use ruststep::ast::Parameter;
     /// let p = Parameter::from_str("FILE_NAME('ruststep')").unwrap();
-    /// assert!(matches!(p, Parameter::Typed(_)));
+    /// assert!(matches!(p, Parameter::Typed { .. }));
     /// ```
-    Typed(SimpleEntityInstance),
+    Typed {
+        keyword: String,
+        parameter: Box<Parameter>,
+    },
 
     /// Signed integer
     ///

--- a/ruststep/src/ast/mod.rs
+++ b/ruststep/src/ast/mod.rs
@@ -60,24 +60,24 @@ derive_ast_from_str!(Name, parser::token::rhs_occurrence_name);
 /// A struct typed in EXPRESS schema, e.g. `A(1.0, 2.0)`
 ///
 /// ```
-/// use ruststep::ast::{Record, Parameter};
+/// use ruststep::ast::{SimpleEntityInstance, Parameter};
 /// use std::str::FromStr;
 ///
-/// let record = Record::from_str("A(1, 2)").unwrap();
+/// let record = SimpleEntityInstance::from_str("A(1, 2)").unwrap();
 /// assert_eq!(
 ///     record,
-///     Record {
+///     SimpleEntityInstance {
 ///         name: "A".to_string(),
 ///         parameter: Box::new(vec![Parameter::Integer(1), Parameter::Integer(2)].into())
 ///     }
 /// )
 /// ```
 #[derive(Debug, Clone, PartialEq)]
-pub struct Record {
+pub struct SimpleEntityInstance {
     pub name: String,
     pub parameter: Box<Parameter>,
 }
-derive_ast_from_str!(Record, parser::exchange::simple_record);
+derive_ast_from_str!(SimpleEntityInstance, parser::exchange::simple_record);
 
 /// `DATA` section in STEP file
 ///
@@ -110,7 +110,7 @@ derive_ast_from_str!(DataSection, parser::exchange::data_section);
 ///
 /// ```
 /// use nom::Finish;
-/// use ruststep::{parser::exchange, ast::{Parameter, Record}};
+/// use ruststep::{parser::exchange, ast::{Parameter, SimpleEntityInstance}};
 ///
 /// let (residual, p) = exchange::parameter("B((1.0, A((2.0, 3.0))))")
 ///     .finish()
@@ -118,13 +118,13 @@ derive_ast_from_str!(DataSection, parser::exchange::data_section);
 /// assert_eq!(residual, "");
 ///
 /// // A((2.0, 3.0))
-/// let a = Parameter::Typed(Record {
+/// let a = Parameter::Typed(SimpleEntityInstance {
 ///     name: "A".to_string(),
 ///     parameter: Box::new(vec![Parameter::real(2.0), Parameter::real(3.0)].into()),
 /// });
 ///
 /// // B((1.0, a))
-/// let b = Parameter::Typed(Record {
+/// let b = Parameter::Typed(SimpleEntityInstance {
 ///     name: "B".to_string(),
 ///     parameter: Box::new(vec![Parameter::real(1.0), a].into()),
 /// });
@@ -154,7 +154,7 @@ pub enum Parameter {
     /// ```
     ///
     /// and [parser::exchange::typed_parameter].
-    /// It takes only one `PARAMETER` different from [Record],
+    /// It takes only one `PARAMETER` different from [SimpleEntityInstance],
     /// which takes many `PARAMETER`s.
     ///
     /// ```text
@@ -167,7 +167,7 @@ pub enum Parameter {
     /// let p = Parameter::from_str("FILE_NAME('ruststep')").unwrap();
     /// assert!(matches!(p, Parameter::Typed(_)));
     /// ```
-    Typed(Record),
+    Typed(SimpleEntityInstance),
 
     /// Signed integer
     ///
@@ -272,7 +272,7 @@ derive_ast_from_str!(Parameter, parser::exchange::parameter);
 #[derive(Debug, Clone, PartialEq)]
 pub struct Exchange {
     /// `HEADER` section
-    pub header: Vec<Record>,
+    pub header: Vec<SimpleEntityInstance>,
     /// `ANCHOR` section
     pub anchor: Vec<Anchor>,
     /// `REFERENCE` section
@@ -287,8 +287,8 @@ derive_ast_from_str!(Exchange, parser::exchange::exchange_file);
 /// Each line of data section
 #[derive(Debug, Clone, PartialEq)]
 pub enum EntityInstance {
-    Simple { id: u64, record: Record },
-    Complex { id: u64, subsuper: Vec<Record> },
+    Simple { id: u64, record: SimpleEntityInstance },
+    Complex { id: u64, subsuper: Vec<SimpleEntityInstance> },
 }
 derive_ast_from_str!(EntityInstance, parser::exchange::entity_instance);
 

--- a/ruststep/src/ast/mod.rs
+++ b/ruststep/src/ast/mod.rs
@@ -287,8 +287,14 @@ derive_ast_from_str!(Exchange, parser::exchange::exchange_file);
 /// Each line of data section
 #[derive(Debug, Clone, PartialEq)]
 pub enum EntityInstance {
-    Simple { id: u64, record: SimpleEntityInstance },
-    Complex { id: u64, subsuper: Vec<SimpleEntityInstance> },
+    Simple {
+        id: u64,
+        record: SimpleEntityInstance,
+    },
+    Complex {
+        id: u64,
+        subsuper: Vec<SimpleEntityInstance>,
+    },
 }
 derive_ast_from_str!(EntityInstance, parser::exchange::entity_instance);
 

--- a/ruststep/src/ast/mod.rs
+++ b/ruststep/src/ast/mod.rs
@@ -57,7 +57,7 @@ pub enum Name {
 }
 derive_ast_from_str!(Name, parser::token::rhs_occurrence_name);
 
-/// A struct typed in EXPRESS schema, e.g. `A(1.0, 2.0)`
+/// Simple entity instance, e.g. `A(1.0, 2.0)`
 ///
 /// ```
 /// use ruststep::ast::{SimpleEntityInstance, Parameter};
@@ -72,6 +72,11 @@ derive_ast_from_str!(Name, parser::token::rhs_occurrence_name);
 ///     }
 /// )
 /// ```
+///
+/// Internal mapping to EXPRESS data types
+/// ---------------------------------------
+/// TBW
+///
 #[derive(Debug, Clone, PartialEq)]
 pub struct SimpleEntityInstance {
     pub keyword: String,
@@ -80,6 +85,11 @@ pub struct SimpleEntityInstance {
 derive_ast_from_str!(SimpleEntityInstance, parser::exchange::simple_record);
 
 /// Complex Entity instance e.g. `(A(1) B(1.0) C("Data Title"))`
+///
+/// External mapping to EXPRESS data types
+/// ---------------------------------------
+/// TBW
+///
 #[derive(Debug, Clone, PartialEq)]
 pub struct ComplexEntityInstance(pub Vec<SimpleEntityInstance>);
 derive_ast_from_str!(ComplexEntityInstance, parser::exchange::subsuper_record);

--- a/ruststep/src/ast/mod.rs
+++ b/ruststep/src/ast/mod.rs
@@ -79,6 +79,11 @@ pub struct SimpleEntityInstance {
 }
 derive_ast_from_str!(SimpleEntityInstance, parser::exchange::simple_record);
 
+/// Complex Entity instance e.g. `(A(1) B(1.0) C("Data Title"))`
+#[derive(Debug, Clone, PartialEq)]
+pub struct ComplexEntityInstance(pub Vec<SimpleEntityInstance>);
+derive_ast_from_str!(ComplexEntityInstance, parser::exchange::subsuper_record);
+
 /// `DATA` section in STEP file
 ///
 /// ```
@@ -292,11 +297,11 @@ derive_ast_from_str!(Exchange, parser::exchange::exchange_file);
 pub enum EntityInstance {
     Simple {
         id: u64,
-        record: SimpleEntityInstance,
+        instance: SimpleEntityInstance,
     },
     Complex {
         id: u64,
-        subsuper: Vec<SimpleEntityInstance>,
+        instance: ComplexEntityInstance,
     },
 }
 derive_ast_from_str!(EntityInstance, parser::exchange::entity_instance);

--- a/ruststep/src/ast/mod.rs
+++ b/ruststep/src/ast/mod.rs
@@ -68,14 +68,14 @@ derive_ast_from_str!(Name, parser::token::rhs_occurrence_name);
 ///     record,
 ///     SimpleEntityInstance {
 ///         name: "A".to_string(),
-///         parameter: Box::new(vec![Parameter::Integer(1), Parameter::Integer(2)].into())
+///         parameters: vec![Parameter::Integer(1), Parameter::Integer(2)],
 ///     }
 /// )
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct SimpleEntityInstance {
     pub name: String,
-    pub parameter: Box<Parameter>,
+    pub parameters: Vec<Parameter>,
 }
 derive_ast_from_str!(SimpleEntityInstance, parser::exchange::simple_record);
 

--- a/ruststep/src/ast/mod.rs
+++ b/ruststep/src/ast/mod.rs
@@ -67,14 +67,14 @@ derive_ast_from_str!(Name, parser::token::rhs_occurrence_name);
 /// assert_eq!(
 ///     record,
 ///     SimpleEntityInstance {
-///         name: "A".to_string(),
+///         keyword: "A".to_string(),
 ///         parameters: vec![Parameter::Integer(1), Parameter::Integer(2)],
 ///     }
 /// )
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct SimpleEntityInstance {
-    pub name: String,
+    pub keyword: String,
     pub parameters: Vec<Parameter>,
 }
 derive_ast_from_str!(SimpleEntityInstance, parser::exchange::simple_record);

--- a/ruststep/src/ast/ser.rs
+++ b/ruststep/src/ast/ser.rs
@@ -301,10 +301,10 @@ impl<'se> ser::SerializeStruct for &'se mut RecordSerializer {
             // restore stacked state
             let name = std::mem::replace(&mut self.name, name);
             let params = std::mem::replace(&mut self.parameters, params);
-            self.parameters.push(Parameter::Typed(SimpleEntityInstance {
-                name,
+            self.parameters.push(Parameter::Typed {
+                keyword: name,
                 parameter: Box::new(params.into_iter().collect()),
-            }));
+            });
         }
         Ok(())
     }

--- a/ruststep/src/ast/ser.rs
+++ b/ruststep/src/ast/ser.rs
@@ -9,7 +9,7 @@ pub fn to_record(obj: &impl ser::Serialize) -> Result<SimpleEntityInstance> {
     assert!(ser.stack.is_empty()); // should panic because this must be bug, not a valid input
     Ok(SimpleEntityInstance {
         name: ser.name,
-        parameter: Box::new(ser.parameters.iter().collect()),
+        parameters: ser.parameters,
     })
 }
 

--- a/ruststep/src/ast/ser.rs
+++ b/ruststep/src/ast/ser.rs
@@ -2,12 +2,12 @@ use crate::{ast::*, error::*};
 use serde::ser;
 use std::convert::TryFrom;
 
-/// Serialize struct into STEP [Record]
-pub fn to_record(obj: &impl ser::Serialize) -> Result<Record> {
+/// Serialize struct into STEP [SimpleEntityInstance]
+pub fn to_record(obj: &impl ser::Serialize) -> Result<SimpleEntityInstance> {
     let mut ser = RecordSerializer::default();
     obj.serialize(&mut ser)?;
     assert!(ser.stack.is_empty()); // should panic because this must be bug, not a valid input
-    Ok(Record {
+    Ok(SimpleEntityInstance {
         name: ser.name,
         parameter: Box::new(ser.parameters.iter().collect()),
     })
@@ -270,18 +270,18 @@ impl<'se> ser::SerializeMap for &'se mut RecordSerializer {
     where
         T: ?Sized + ser::Serialize,
     {
-        unimplemented!("Serialize Map to Record is not supported yet.")
+        unimplemented!("Serialize Map to SimpleEntityInstance is not supported yet.")
     }
 
     fn serialize_value<T>(&mut self, _value: &T) -> Result<()>
     where
         T: ?Sized + ser::Serialize,
     {
-        unimplemented!("Serialize Map to Record is not supported yet.")
+        unimplemented!("Serialize Map to SimpleEntityInstance is not supported yet.")
     }
 
     fn end(self) -> Result<()> {
-        unimplemented!("Serialize Map to Record is not supported yet.")
+        unimplemented!("Serialize Map to SimpleEntityInstance is not supported yet.")
     }
 }
 
@@ -301,7 +301,7 @@ impl<'se> ser::SerializeStruct for &'se mut RecordSerializer {
             // restore stacked state
             let name = std::mem::replace(&mut self.name, name);
             let params = std::mem::replace(&mut self.parameters, params);
-            self.parameters.push(Parameter::Typed(Record {
+            self.parameters.push(Parameter::Typed(SimpleEntityInstance {
                 name,
                 parameter: Box::new(params.into_iter().collect()),
             }));

--- a/ruststep/src/header.rs
+++ b/ruststep/src/header.rs
@@ -102,7 +102,7 @@ pub struct Header {
 }
 
 impl Header {
-    pub fn from_records(records: &[Record]) -> Result<Self> {
+    pub fn from_records(records: &[SimpleEntityInstance]) -> Result<Self> {
         assert!(records.len() >= 3);
         let file_description = FileDescription::deserialize(&records[0])?;
         let file_name = FileName::deserialize(&records[1])?;

--- a/ruststep/src/lib.rs
+++ b/ruststep/src/lib.rs
@@ -86,7 +86,7 @@
 //! - `HEADER` section has three components `FILE_DESCRIPTION`, `FILE_NAME`, and `FILE_SCHEMA`.
 //!   - See [header] module document for detail.
 //! - Each data is in form `TYPE_NAME(parameter1, ...)`.
-//!   - This is called "Record".
+//!   - This is called "SimpleEntityInstance".
 //!   - Each records is bounded by a number.
 //!   - Parameter can be
 //!     - Floating number, e.g. `0.0`

--- a/ruststep/src/parser/exchange/data.rs
+++ b/ruststep/src/parser/exchange/data.rs
@@ -54,9 +54,9 @@ pub fn complex_entity_instance(input: &str) -> ParseResult<EntityInstance> {
 /// simple_record = [keyword] `(` \[ [parameter_list] \] `)` .
 pub fn simple_record(input: &str) -> ParseResult<SimpleEntityInstance> {
     tuple_((keyword, char_('('), opt_(parameter_list), char_(')')))
-        .map(|(name, _open, parameter, _close)| SimpleEntityInstance {
+        .map(|(name, _open, parameters, _close)| SimpleEntityInstance {
             name,
-            parameter: Box::new(parameter.unwrap_or_default().into_iter().collect()),
+            parameters: parameters.unwrap_or_default().into_iter().collect(),
         })
         .parse(input)
 }

--- a/ruststep/src/parser/exchange/data.rs
+++ b/ruststep/src/parser/exchange/data.rs
@@ -52,9 +52,9 @@ pub fn complex_entity_instance(input: &str) -> ParseResult<EntityInstance> {
 }
 
 /// simple_record = [keyword] `(` \[ [parameter_list] \] `)` .
-pub fn simple_record(input: &str) -> ParseResult<Record> {
+pub fn simple_record(input: &str) -> ParseResult<SimpleEntityInstance> {
     tuple_((keyword, char_('('), opt_(parameter_list), char_(')')))
-        .map(|(name, _open, parameter, _close)| Record {
+        .map(|(name, _open, parameter, _close)| SimpleEntityInstance {
             name,
             parameter: Box::new(parameter.unwrap_or_default().into_iter().collect()),
         })
@@ -62,12 +62,12 @@ pub fn simple_record(input: &str) -> ParseResult<Record> {
 }
 
 /// simple_record_list = [simple_record] { [simple_record] } .
-pub fn simple_record_list(input: &str) -> ParseResult<Vec<Record>> {
+pub fn simple_record_list(input: &str) -> ParseResult<Vec<SimpleEntityInstance>> {
     many0_(simple_record).parse(input)
 }
 
 /// subsuper_record = `(` [simple_record_list] `)` .
-pub fn subsuper_record(input: &str) -> ParseResult<Vec<Record>> {
+pub fn subsuper_record(input: &str) -> ParseResult<Vec<SimpleEntityInstance>> {
     tuple_((char_('('), simple_record_list, char_(')')))
         .map(|(_open, records, _close)| records)
         .parse(input)

--- a/ruststep/src/parser/exchange/data.rs
+++ b/ruststep/src/parser/exchange/data.rs
@@ -54,10 +54,12 @@ pub fn complex_entity_instance(input: &str) -> ParseResult<EntityInstance> {
 /// simple_record = [keyword] `(` \[ [parameter_list] \] `)` .
 pub fn simple_record(input: &str) -> ParseResult<SimpleEntityInstance> {
     tuple_((keyword, char_('('), opt_(parameter_list), char_(')')))
-        .map(|(name, _open, parameters, _close)| SimpleEntityInstance {
-            name,
-            parameters: parameters.unwrap_or_default().into_iter().collect(),
-        })
+        .map(
+            |(keyword, _open, parameters, _close)| SimpleEntityInstance {
+                keyword,
+                parameters: parameters.unwrap_or_default().into_iter().collect(),
+            },
+        )
         .parse(input)
 }
 

--- a/ruststep/src/parser/exchange/header.rs
+++ b/ruststep/src/parser/exchange/header.rs
@@ -5,14 +5,14 @@ use crate::{
 use nom::Parser;
 
 /// header_section = `HEADER;` [header_entity] [header_entity] [header_entity] \[ [header_entity_list] \] `ENDSEC;` .
-pub fn header_section(input: &str) -> ParseResult<Vec<Record>> {
+pub fn header_section(input: &str) -> ParseResult<Vec<SimpleEntityInstance>> {
     tuple_((tag_("HEADER;"), header_entity_list, tag_("ENDSEC;")))
         .map(|(_start, entities, _close)| entities)
         .parse(input)
 }
 
 /// header_entity_list = [header_entity] { [header_entity] } .
-pub fn header_entity_list(input: &str) -> ParseResult<Vec<Record>> {
+pub fn header_entity_list(input: &str) -> ParseResult<Vec<SimpleEntityInstance>> {
     many1_(header_entity).parse(input)
 }
 
@@ -23,7 +23,7 @@ pub fn header_entity_list(input: &str) -> ParseResult<Vec<Record>> {
 /// ```text
 /// header_entity = keyword ( [ parameter_list ] ) ; .
 /// ```
-pub fn header_entity(input: &str) -> ParseResult<Record> {
+pub fn header_entity(input: &str) -> ParseResult<SimpleEntityInstance> {
     tuple_((simple_record, char_(';')))
         .map(|(record, _semicolon)| record)
         .parse(input)

--- a/ruststep/src/parser/exchange/parameter.rs
+++ b/ruststep/src/parser/exchange/parameter.rs
@@ -20,7 +20,7 @@ pub fn parameter(input: &str) -> ParseResult<Parameter> {
 pub fn typed_parameter(input: &str) -> ParseResult<Parameter> {
     tuple_((keyword, char_('('), parameter, char_(')')))
         .map(|(name, _open, ty, _close)| {
-            Parameter::Typed(Record {
+            Parameter::Typed(SimpleEntityInstance {
                 name,
                 parameter: Box::new(ty),
             })

--- a/ruststep/src/parser/exchange/parameter.rs
+++ b/ruststep/src/parser/exchange/parameter.rs
@@ -19,11 +19,9 @@ pub fn parameter(input: &str) -> ParseResult<Parameter> {
 /// typed_parameter = [keyword] `(` [parameter] `)` .
 pub fn typed_parameter(input: &str) -> ParseResult<Parameter> {
     tuple_((keyword, char_('('), parameter, char_(')')))
-        .map(|(name, _open, ty, _close)| {
-            Parameter::Typed(SimpleEntityInstance {
-                name,
-                parameter: Box::new(ty),
-            })
+        .map(|(name, _open, ty, _close)| Parameter::Typed {
+            keyword: name,
+            parameter: Box::new(ty),
         })
         .parse(input)
 }

--- a/ruststep/src/parser/mod.rs
+++ b/ruststep/src/parser/mod.rs
@@ -65,7 +65,7 @@ use nom::Finish;
 /// let (residual, header) = ruststep::parser::parse_header(&step_str).unwrap();
 /// assert_eq!(residual, ""); // consume HEADER section of `step_str`
 /// ```
-pub fn parse_header(input: &str) -> Result<(&str, Vec<ast::Record>)> {
+pub fn parse_header(input: &str) -> Result<(&str, Vec<ast::SimpleEntityInstance>)> {
     match exchange::header_section(input).finish() {
         Ok((input, records)) => Ok((input, records)),
         Err(e) => Err(TokenizeFailed::new(input, e).into()),

--- a/ruststep/src/tables.rs
+++ b/ruststep/src/tables.rs
@@ -192,7 +192,7 @@ where
 pub fn insert_record<'de, T: de::Deserialize<'de>>(
     table: &mut HashMap<u64, T>,
     id: u64,
-    record: &Record,
+    record: &SimpleEntityInstance,
 ) -> crate::error::Result<()> {
     if let Some(_) = table.insert(id, de::Deserialize::deserialize(record)?) {
         Err(Error::DuplicatedEntity(id))
@@ -331,7 +331,7 @@ impl<'de, T: Deserialize<'de> + Holder + WithVisitor> de::Visitor<'de> for Place
         }
     }
 
-    // Entry point for Record or Parameter::Typed
+    // Entry point for SimpleEntityInstance or Parameter::Typed
     fn visit_map<A>(self, map: A) -> ::std::result::Result<Self::Value, A::Error>
     where
         A: de::MapAccess<'de>,

--- a/ruststep/tests/any.rs
+++ b/ruststep/tests/any.rs
@@ -33,7 +33,7 @@ ENDSEC;
 
 #[test]
 fn deserialize_base() {
-    let (residual, p): (_, Record) = exchange::simple_record("BASE(1.0)").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("BASE(1.0)").finish().unwrap();
     dbg!(&p);
     assert_eq!(residual, "");
 
@@ -60,7 +60,7 @@ fn deserialize_sub1() {
     );
 
     fn test(input: &str, answer: Sub1Holder) {
-        let (residual, p): (_, Record) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
 
@@ -88,7 +88,7 @@ fn deserialize_base_any() {
     );
 
     fn test(input: &str, answer: BaseAnyHolder) {
-        let (residual, p): (_, Record) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
 
@@ -116,7 +116,7 @@ fn deserialize_base_any_placeholder() {
     );
 
     fn test(input: &str, answer: PlaceHolder<BaseAnyHolder>) {
-        let (residual, p): (_, Record) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
 
@@ -146,7 +146,7 @@ fn into_base_any() {
     fn test(input: &str, answer: BaseAny) {
         let table = Tables::from_str(EXAMPLE).unwrap();
 
-        let (residual, p): (_, Record) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
 

--- a/ruststep/tests/any.rs
+++ b/ruststep/tests/any.rs
@@ -33,7 +33,8 @@ ENDSEC;
 
 #[test]
 fn deserialize_base() {
-    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("BASE(1.0)").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) =
+        exchange::simple_record("BASE(1.0)").finish().unwrap();
     dbg!(&p);
     assert_eq!(residual, "");
 
@@ -60,7 +61,8 @@ fn deserialize_sub1() {
     );
 
     fn test(input: &str, answer: Sub1Holder) {
-        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) =
+            exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
 
@@ -88,7 +90,8 @@ fn deserialize_base_any() {
     );
 
     fn test(input: &str, answer: BaseAnyHolder) {
-        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) =
+            exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
 
@@ -116,7 +119,8 @@ fn deserialize_base_any_placeholder() {
     );
 
     fn test(input: &str, answer: PlaceHolder<BaseAnyHolder>) {
-        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) =
+            exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
 
@@ -146,7 +150,8 @@ fn into_base_any() {
     fn test(input: &str, answer: BaseAny) {
         let table = Tables::from_str(EXAMPLE).unwrap();
 
-        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) =
+            exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
 

--- a/ruststep/tests/entity.rs
+++ b/ruststep/tests/entity.rs
@@ -34,8 +34,8 @@ ENDSEC;
 
 #[test]
 fn deserialize_a_holder() {
-    // from Record
-    let (residual, p): (_, Record) = exchange::simple_record("A(1.0, 2.0)").finish().unwrap();
+    // from SimpleEntityInstance
+    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("A(1.0, 2.0)").finish().unwrap();
     assert_eq!(residual, "");
     dbg!(&p);
     let a: AHolder = Deserialize::deserialize(&p).unwrap();
@@ -49,7 +49,7 @@ fn deserialize_a_holder() {
     assert_eq!(a, AHolder { x: 1.0, y: 2.0 });
 
     // Test for PlaceHolder<AHolder>
-    let (residual, p): (_, Record) = exchange::simple_record("A(1.0, 2.0)").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("A(1.0, 2.0)").finish().unwrap();
     assert_eq!(residual, "");
     dbg!(&p);
     let a: PlaceHolder<AHolder> = Deserialize::deserialize(&p).unwrap();
@@ -58,8 +58,8 @@ fn deserialize_a_holder() {
 
 #[test]
 fn deserialize_b_holder_record() {
-    // from Record
-    let (residual, p): (_, Record) = exchange::simple_record("B(1.0, A((2.0, 3.0)))")
+    // from SimpleEntityInstance
+    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("B(1.0, A((2.0, 3.0)))")
         .finish()
         .unwrap();
     assert_eq!(residual, "");
@@ -76,8 +76,8 @@ fn deserialize_b_holder_record() {
 
 #[test]
 fn deserialize_b_holder_record_ref() {
-    // from Record with ref
-    let (residual, p): (_, Record) = exchange::simple_record("B(1.0, #2)").finish().unwrap();
+    // from SimpleEntityInstance with ref
+    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("B(1.0, #2)").finish().unwrap();
     assert_eq!(residual, "");
     dbg!(&p);
     let b: BHolder = Deserialize::deserialize(&p).unwrap();

--- a/ruststep/tests/entity.rs
+++ b/ruststep/tests/entity.rs
@@ -35,7 +35,8 @@ ENDSEC;
 #[test]
 fn deserialize_a_holder() {
     // from SimpleEntityInstance
-    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("A(1.0, 2.0)").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) =
+        exchange::simple_record("A(1.0, 2.0)").finish().unwrap();
     assert_eq!(residual, "");
     dbg!(&p);
     let a: AHolder = Deserialize::deserialize(&p).unwrap();
@@ -49,7 +50,8 @@ fn deserialize_a_holder() {
     assert_eq!(a, AHolder { x: 1.0, y: 2.0 });
 
     // Test for PlaceHolder<AHolder>
-    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("A(1.0, 2.0)").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) =
+        exchange::simple_record("A(1.0, 2.0)").finish().unwrap();
     assert_eq!(residual, "");
     dbg!(&p);
     let a: PlaceHolder<AHolder> = Deserialize::deserialize(&p).unwrap();
@@ -77,7 +79,8 @@ fn deserialize_b_holder_record() {
 #[test]
 fn deserialize_b_holder_record_ref() {
     // from SimpleEntityInstance with ref
-    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("B(1.0, #2)").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) =
+        exchange::simple_record("B(1.0, #2)").finish().unwrap();
     assert_eq!(residual, "");
     dbg!(&p);
     let b: BHolder = Deserialize::deserialize(&p).unwrap();

--- a/ruststep/tests/list.rs
+++ b/ruststep/tests/list.rs
@@ -28,7 +28,7 @@ use test_schema::*;
 
 #[test]
 fn deserialize_list_a() {
-    let (residual, p): (_, Record) = exchange::simple_record("A((1.0, 2.0))").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("A((1.0, 2.0))").finish().unwrap();
     dbg!(&p);
     assert_eq!(residual, "");
     let a: AHolder = Deserialize::deserialize(&p).unwrap();
@@ -38,7 +38,7 @@ fn deserialize_list_a() {
 
 #[test]
 fn deserialize_list_b() {
-    let (residual, p): (_, Record) = exchange::simple_record("B((A(((1.0)))))").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("B((A(((1.0)))))").finish().unwrap();
     dbg!(&p);
     assert_eq!(residual, "");
     let b: BHolder = Deserialize::deserialize(&p).unwrap();
@@ -53,7 +53,7 @@ fn deserialize_list_b() {
 
 #[test]
 fn deserialize_list_c() {
-    let (residual, p): (_, Record) =
+    let (residual, p): (_, SimpleEntityInstance) =
         exchange::simple_record("C( ( ( A(((1.0))) ), ( A(((2.0))) ) ) )")
             .finish()
             .unwrap();

--- a/ruststep/tests/list.rs
+++ b/ruststep/tests/list.rs
@@ -28,7 +28,8 @@ use test_schema::*;
 
 #[test]
 fn deserialize_list_a() {
-    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("A((1.0, 2.0))").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) =
+        exchange::simple_record("A((1.0, 2.0))").finish().unwrap();
     dbg!(&p);
     assert_eq!(residual, "");
     let a: AHolder = Deserialize::deserialize(&p).unwrap();
@@ -38,7 +39,8 @@ fn deserialize_list_a() {
 
 #[test]
 fn deserialize_list_b() {
-    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("B((A(((1.0)))))").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) =
+        exchange::simple_record("B((A(((1.0)))))").finish().unwrap();
     dbg!(&p);
     assert_eq!(residual, "");
     let b: BHolder = Deserialize::deserialize(&p).unwrap();

--- a/ruststep/tests/subsuper.rs
+++ b/ruststep/tests/subsuper.rs
@@ -27,7 +27,7 @@ use test_schema::*;
 
 #[test]
 fn deserialize_base() {
-    let (residual, p): (_, Record) = exchange::simple_record("BASE(1.0)").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("BASE(1.0)").finish().unwrap();
     dbg!(&p);
     assert_eq!(residual, "");
     let a: BaseHolder = Deserialize::deserialize(&p).unwrap();
@@ -52,7 +52,7 @@ fn deserialize_sub() {
         },
     );
     fn test(input: &str, answer: SubHolder) {
-        let (residual, p): (_, Record) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
         let a: SubHolder = Deserialize::deserialize(&p).unwrap();
@@ -75,7 +75,7 @@ fn deserialize_subsub() {
         },
     );
     fn test(input: &str, answer: SubsubHolder) {
-        let (residual, p): (_, Record) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
         let a: SubsubHolder = Deserialize::deserialize(&p).unwrap();

--- a/ruststep/tests/subsuper.rs
+++ b/ruststep/tests/subsuper.rs
@@ -27,7 +27,8 @@ use test_schema::*;
 
 #[test]
 fn deserialize_base() {
-    let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record("BASE(1.0)").finish().unwrap();
+    let (residual, p): (_, SimpleEntityInstance) =
+        exchange::simple_record("BASE(1.0)").finish().unwrap();
     dbg!(&p);
     assert_eq!(residual, "");
     let a: BaseHolder = Deserialize::deserialize(&p).unwrap();
@@ -52,7 +53,8 @@ fn deserialize_sub() {
         },
     );
     fn test(input: &str, answer: SubHolder) {
-        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) =
+            exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
         let a: SubHolder = Deserialize::deserialize(&p).unwrap();
@@ -75,7 +77,8 @@ fn deserialize_subsub() {
         },
     );
     fn test(input: &str, answer: SubsubHolder) {
-        let (residual, p): (_, SimpleEntityInstance) = exchange::simple_record(input).finish().unwrap();
+        let (residual, p): (_, SimpleEntityInstance) =
+            exchange::simple_record(input).finish().unwrap();
         dbg!(&p);
         assert_eq!(residual, "");
         let a: SubsubHolder = Deserialize::deserialize(&p).unwrap();


### PR DESCRIPTION
Split from #220 

- [x] Do not use `RecordDeserializer` for `Parameter::Ref` → #224
- [x] Fix "map" to "newtype_struct" for `ast::Name` → #224 
- [x] Rename `Record` into `SimpleEntityInstance`
- [ ] Introduce `ComplexEntityInstance` struct and implement `Deserializer`
- [ ] Change mapping of `Parameter::Typed` and `Record` into "struct" in serde model