### PR TITLE
Do not use `RecordDeserializer` for `Name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 - `SUBTYPE_CONSTRAINT` cannot parse supertype-constraint like `ONEOF` https://github.com/ricosjp/ruststep/pull/205
 
 ### Internal
+- Do not use RecordDeserializer for Name https://github.com/ricosjp/ruststep/pull/224
 - Use Instantiables instead of Constraint https://github.com/ricosjp/ruststep/pull/206
 - Return index from ir::Namespace::resolve https://github.com/ricosjp/ruststep/pull/204
 - cargo clippy --fix https://github.com/ricosjp/ruststep/pull/202

--- a/ruststep/src/ast/de/deserializer.rs
+++ b/ruststep/src/ast/de/deserializer.rs
@@ -75,7 +75,7 @@ impl RecordDeserializer {
     pub fn new(key: &str, value: Parameter) -> Self {
         RecordDeserializer {
             key: Some(key.to_string()),
-            value: value,
+            value,
         }
     }
 }

--- a/ruststep/src/ast/de/deserializer.rs
+++ b/ruststep/src/ast/de/deserializer.rs
@@ -41,7 +41,7 @@ impl<'de> de::SeqAccess<'de> for SeqDeserializer {
 #[derive(Debug)]
 pub struct RecordDeserializer {
     key: Option<String>,
-    value: Option<Parameter>,
+    value: Parameter,
 }
 
 impl<'de, 'record> de::IntoDeserializer<'de, crate::error::Error> for &'record Record {
@@ -49,7 +49,7 @@ impl<'de, 'record> de::IntoDeserializer<'de, crate::error::Error> for &'record R
     fn into_deserializer(self) -> RecordDeserializer {
         RecordDeserializer {
             key: Some(self.name.to_string()),
-            value: Some(*self.parameter.clone()),
+            value: *self.parameter.clone(),
         }
     }
 }
@@ -75,7 +75,7 @@ impl RecordDeserializer {
     pub fn new(key: &str, value: Parameter) -> Self {
         RecordDeserializer {
             key: Some(key.to_string()),
-            value: Some(value),
+            value: value,
         }
     }
 }
@@ -101,12 +101,8 @@ impl<'de> de::MapAccess<'de> for RecordDeserializer {
     where
         V: de::DeserializeSeed<'de>,
     {
-        if let Some(value) = self.value.take() {
-            let value: V::Value = seed.deserialize(&value)?;
-            Ok(value)
-        } else {
-            unreachable!("next_value_seed before next_key_seed is incorrect.")
-        }
+        let value: V::Value = seed.deserialize(&self.value)?;
+        Ok(value)
     }
 }
 

--- a/ruststep/src/ast/de/deserializer.rs
+++ b/ruststep/src/ast/de/deserializer.rs
@@ -110,59 +110,66 @@ impl<'de> de::MapAccess<'de> for RecordDeserializer {
     }
 }
 
-// Entry point of `visit_enum`
-impl<'de> de::EnumAccess<'de> for RecordDeserializer {
-    type Error = crate::error::Error;
-    type Variant = Self; // this requires `VariantAccess` (see below impl)
-
-    fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant)>
-    where
-        V: de::DeserializeSeed<'de>,
-    {
-        match de::MapAccess::next_key_seed(&mut self, seed)? {
-            Some(key) => Ok((key, self)),
-            None => Err(de::Error::invalid_type(de::Unexpected::Map, &"enum")),
-        }
-    }
-}
-
-// As serde document says,
+// Note for understanding serde enum types
+// ----------------------------------------
 //
-// https://docs.serde.rs/serde/de/trait.VariantAccess.html
-//
-// > VariantAccess is a visitor that is created by the Deserializer
-// > and passed to the Deserialize to deserialize the content of a particular enum variant.
-//
-// this trait is used for 4 data models:
+// In serde impl, we have to implement `VariantAccess` and `EnumAccess`
+// since `Visitor::visit_enum` requires `EnumAccess` and it requires `VariantAccess`.
+// `VariantAccess` and `EnumAccess` traits are used for 4 data models:
 //
 // - "unit_variant"    e.g. the `E::A` and `E::B` in `enum E { A, B }`
 // - "newtype_variant" e.g. the `E::N` in `enum E { N(u8) }`
 // - "tuple_variant"   e.g. the `E::T` in `enum E { T(u8, u8) }`
 // - "struct_variant"  e.g. the `E::S` in `enum E { S { r: u8, g: u8, b: u8 } }`
 //
-// But, `RecordDeserializer` is only used for "newtype_variant" case,
-// and returns `Err` in other cases.
+// Roughly, `EnumAccess` determines which variant are used e.g. `E::N` in above "newtype_variant" case,
+// and `VariantAccess` determines its component e.g. `1u8`.
+// These are composed into `E::N(1u8)` in `Visitor::visit_enum`.
 //
-impl<'de> de::VariantAccess<'de> for RecordDeserializer {
+impl<'de, 'name> de::EnumAccess<'de> for &'name Name {
+    type Error = crate::error::Error;
+    type Variant = Self;
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let key: de::value::StrDeserializer<Self::Error> = match self {
+            Name::Entity(_) => "Entity",
+            Name::Value(_) => "Value",
+            Name::ConstantEntity(_) => "ConstantEntity",
+            Name::ConstantValue(_) => "ConstantValue",
+        }
+        .into_deserializer();
+        let key: V::Value = seed.deserialize(key)?;
+        Ok((key, self))
+    }
+}
+
+impl<'de, 'name> de::VariantAccess<'de> for &'name Name {
     type Error = crate::error::Error;
 
     fn unit_variant(self) -> Result<()> {
-        let unexp = de::Unexpected::Map;
+        let unexp = de::Unexpected::NewtypeVariant;
         Err(de::Error::invalid_type(unexp, &"unit variant"))
     }
 
-    fn newtype_variant_seed<D>(mut self, seed: D) -> Result<D::Value>
+    fn newtype_variant_seed<D>(self, seed: D) -> Result<D::Value>
     where
         D: de::DeserializeSeed<'de>,
     {
-        de::MapAccess::next_value_seed(&mut self, seed)
+        match self {
+            Name::Entity(id) | Name::Value(id) => seed.deserialize(id.into_deserializer()),
+            Name::ConstantEntity(name) | Name::ConstantValue(name) => {
+                seed.deserialize(name.as_str().into_deserializer())
+            }
+        }
     }
 
     fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
-        let unexp = de::Unexpected::Map;
+        let unexp = de::Unexpected::NewtypeVariant;
         Err(de::Error::invalid_type(unexp, &"tuple variant"))
     }
 
@@ -170,7 +177,7 @@ impl<'de> de::VariantAccess<'de> for RecordDeserializer {
     where
         V: de::Visitor<'de>,
     {
-        let unexp = de::Unexpected::Map;
+        let unexp = de::Unexpected::NewtypeVariant;
         Err(de::Error::invalid_type(unexp, &"struct variant"))
     }
 }

--- a/ruststep/src/ast/de/mod.rs
+++ b/ruststep/src/ast/de/mod.rs
@@ -23,7 +23,7 @@
 //! | Omitted     | option (always none)|
 //! | Enumeration | unit_variant (through [serde::de::value::StringDeserializer])|
 //! | Typed       | map (through [RecordDeserializer])|
-//! | Ref         | newtype_variant (through [RecordDeserializer])|
+//! | Ref         | newtype_variant  |
 //!
 //! Be sure that this mapping is not only for espr-generated structs.
 //! This can be used with other Rust structs using `serde_derive::Deserialize` custom derive:

--- a/ruststep/src/ast/de/parameter.rs
+++ b/ruststep/src/ast/de/parameter.rs
@@ -36,7 +36,7 @@ impl<'de, 'param> de::Deserializer<'de> for &'param Parameter {
             Parameter::Real(val) => visitor.visit_f64(*val),
             Parameter::String(val) => visitor.visit_str(val),
             Parameter::List(params) => visitor.visit_seq(SeqDeserializer::new(params)),
-            Parameter::Ref(name) => visitor.visit_enum(name_to_reserializer(name.clone())),
+            Parameter::Ref(name) => visitor.visit_enum(name),
             Parameter::NotProvided | Parameter::Omitted => visitor.visit_none(),
             Parameter::Enumeration(variant) => {
                 visitor.visit_enum(variant.to_class_case().into_deserializer())
@@ -48,18 +48,5 @@ impl<'de, 'param> de::Deserializer<'de> for &'param Parameter {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         struct tuple_struct map enum identifier ignored_any
-    }
-}
-
-fn name_to_reserializer(name: Name) -> RecordDeserializer {
-    match name {
-        Name::Entity(id) => RecordDeserializer::new("Entity", Parameter::Integer(id as i64)),
-        Name::Value(id) => RecordDeserializer::new("Value", Parameter::Integer(id as i64)),
-        Name::ConstantEntity(name) => {
-            RecordDeserializer::new("ConstantEntity", Parameter::String(name))
-        }
-        Name::ConstantValue(name) => {
-            RecordDeserializer::new("ConstantValue", Parameter::String(name))
-        }
     }
 }


### PR DESCRIPTION
Split from #222, additional fix of #220

- Do not use `RecordDeserializer` for `Parameter::Ref`
- Fix serde data model mapping from "map" to "newtype_struct" for `ast::Name`