### PR TITLE
deserialize logical and bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 ## Unreleased
 
 ### Added
+- Deserialize `LOGICAL` and `BOOLEAN` by `.T.`, `.F.`, and `.U.` notations.
 
 ### Changed
 

--- a/ruststep/src/ast/de/parameter.rs
+++ b/ruststep/src/ast/de/parameter.rs
@@ -29,8 +29,25 @@ impl<'de, 'param> de::Deserializer<'de> for &'param Parameter {
         }
     }
 
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if let Parameter::Enumeration(variant) = self {
+            match variant.as_str() {
+                "T" => visitor.visit_bool(true),
+                "TRUE" => visitor.visit_bool(true),
+                "F" => visitor.visit_bool(false),
+                "FALSE" => visitor.visit_bool(false),
+                _ => visitor.visit_enum(variant.to_class_case().into_deserializer()),
+            }
+        } else {
+            self.deserialize_any(visitor)
+        }
+    }
+
     forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         struct tuple_struct map enum identifier ignored_any
     }

--- a/ruststep/tests/bool_logical_deserialize.rs
+++ b/ruststep/tests/bool_logical_deserialize.rs
@@ -1,0 +1,35 @@
+use ruststep::{ast::*, primitive::*};
+use serde::Deserialize;
+
+fn sub_deserialize<T>(param: &str, ans: T)
+where
+    T: std::fmt::Debug + PartialEq + Deserialize<'static>,
+{
+    let p = Parameter::Enumeration(param.to_string());
+    let x: T = Deserialize::deserialize(&p).unwrap();
+    assert_eq!(x, ans);
+}
+
+#[test]
+fn bool_deserialize() {
+    sub_deserialize("T", true);
+    sub_deserialize("TRUE", true);
+    sub_deserialize("F", false);
+    sub_deserialize("FALSE", false);
+
+    let p = Parameter::Enumeration("UNKNOWN".to_string());
+    assert!(bool::deserialize(&p).is_err());
+}
+
+#[test]
+fn deserialize_logical() {
+    sub_deserialize("T", Logical::True);
+    sub_deserialize("TRUE", Logical::True);
+    sub_deserialize("F", Logical::False);
+    sub_deserialize("FALSE", Logical::False);
+    sub_deserialize("U", Logical::Unknown);
+    sub_deserialize("Unknown", Logical::Unknown);
+
+    let p = Parameter::Enumeration("Q".to_string());
+    assert!(Logical::deserialize(&p).is_err());
+}


### PR DESCRIPTION
Deserialize `LOGICAL` and `BOOLEAN` by `.T.`, `.F.`, and `.U.` notations.