### PR TITLE
Fixed bug in logical_listeral parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,22 +15,28 @@ In addition to original Keep-a-Changelog, we use following rules:
 ## Unreleased
 
 ### Added
+
 - Deserialize `LOGICAL` and `BOOLEAN` by `.T.`, `.F.`, and `.U.` notations. https://github.com/ricosjp/ruststep/pull/231
 
 ### Changed
+
 - Remove `field` attr from enumerations. https://github.com/ricosjp/ruststep/pull/233
 - Recursive `get_owned` for select type without boxed variant. https://github.com/ricosjp/ruststep/pull/234
 
 ### Fixed
+
+- Fixed bug in logical_listeral parser #244
 - Deseialize `Option::Some`. https://github.com/ricosjp/ruststep/pull/232
 - Recursive implementation of `ruststep::tables::EntityTable::{get_owned, owned_iter}` for select types. https://github.com/ricosjp/ruststep/pull/230
 
 ### Internal
+
 - `cargo upgrade --workspace` https://github.com/ricosjp/ruststep/pull/240
 
 ## 0.3.0 - 2022-06-14
 
 ### Added
+
 - Deserialize Record as a struct https://github.com/ricosjp/ruststep/pull/228
 - Add `ruststep::ast::SubSuperRecord` https://github.com/ricosjp/ruststep/pull/225
 - Document and tests for serde mapping in ruststep::ast::de https://github.com/ricosjp/ruststep/pull/220
@@ -42,13 +48,16 @@ In addition to original Keep-a-Changelog, we use following rules:
 - Partial complex entities described in ISO-10303-11 Annex B https://github.com/ricosjp/ruststep/pull/200
 
 ### Changed
+
 - `ruststep::ast::RValue` is renamed to `Name` https://github.com/ricosjp/ruststep/pull/219
 - `ruststep::place_holder` is integrated into `ruststep::tables` https://github.com/ricosjp/ruststep/pull/216
 
 ### Fixed
+
 - `SUBTYPE_CONSTRAINT` cannot parse supertype-constraint like `ONEOF` https://github.com/ricosjp/ruststep/pull/205
 
 ### Internal
+
 - Document for internal mapping https://github.com/ricosjp/ruststep/pull/226
 - Reconstruct documents of ast::de https://github.com/ricosjp/ruststep/pull/229
 - Do not use RecordDeserializer for Name https://github.com/ricosjp/ruststep/pull/224
@@ -60,6 +69,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 ## 0.2.0 - 2022-02-17
 
 ### Added
+
 - Re-expose serde and itertools from ruststep https://github.com/ricosjp/ruststep/pull/199
 - Add the module created from AP203. https://github.com/ricosjp/ruststep/pull/185
 - Implement `AsRef` and `AsMut` for `XXAny`. https://github.com/ricosjp/ruststep/pull/180
@@ -78,8 +88,9 @@ In addition to original Keep-a-Changelog, we use following rules:
 - impl `FromStr` for `Record` and `DataSection` https://github.com/ricosjp/ruststep/pull/140
 
 ### Changed
+
 - Generate Holder struct for TYPE declaration with simple type. https://github.com/ricosjp/ruststep/pull/186
-- Replace the methods `xxx_iter` of `Tables` with `xxx_holder`.  https://github.com/ricosjp/ruststep/pull/187
+- Replace the methods `xxx_iter` of `Tables` with `xxx_holder`. https://github.com/ricosjp/ruststep/pull/187
 - Cut out `IntoOwned` trait from `Holder`. https://github.com/ricosjp/ruststep/pull/183
 - Translates `TYPE` declarations in EXPRESS to Rust tuple struct https://github.com/ricosjp/ruststep/pull/144
 - Visitor struct and all fields in Holder struct become public https://github.com/ricosjp/ruststep/pull/160
@@ -88,6 +99,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 - Use Rust 2021 edition https://github.com/ricosjp/ruststep/pull/128
 
 ### Fixed
+
 - Incorrect `GENERIC` type handling https://github.com/ricosjp/ruststep/pull/198
 - Subtype-Supertype dependency graph generation fixed https://github.com/ricosjp/ruststep/pull/161
 - Supertype field is not included in subtypes type https://github.com/ricosjp/ruststep/pull/166
@@ -95,6 +107,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 - Use raw identifier `r#` for reserved words. https://github.com/ricosjp/ruststep/pull/172
 
 ### Internal
+
 - impl `SeqDeserializer::size_hint` https://github.com/ricosjp/ruststep/pull/197
 - Replace `SeqDeserializer` https://github.com/ricosjp/ruststep/pull/194
 - Use `Record` struct in `Parameter::Typed` https://github.com/ricosjp/ruststep/pull/192

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 
 ### Fixed
 
-- Fixed bug in logical_listeral parser #244
+- Fixed bug in logical_listeral parser. https://github.com/ricosjp/ruststep/pull/244
 - Deseialize `Option::Some`. https://github.com/ricosjp/ruststep/pull/232
 - Recursive implementation of `ruststep::tables::EntityTable::{get_owned, owned_iter}` for select types. https://github.com/ricosjp/ruststep/pull/230
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,28 +15,23 @@ In addition to original Keep-a-Changelog, we use following rules:
 ## Unreleased
 
 ### Added
-
 - Deserialize `LOGICAL` and `BOOLEAN` by `.T.`, `.F.`, and `.U.` notations. https://github.com/ricosjp/ruststep/pull/231
 
 ### Changed
-
 - Remove `field` attr from enumerations. https://github.com/ricosjp/ruststep/pull/233
 - Recursive `get_owned` for select type without boxed variant. https://github.com/ricosjp/ruststep/pull/234
 
 ### Fixed
-
 - Fixed bug in logical_listeral parser. https://github.com/ricosjp/ruststep/pull/244
 - Deseialize `Option::Some`. https://github.com/ricosjp/ruststep/pull/232
 - Recursive implementation of `ruststep::tables::EntityTable::{get_owned, owned_iter}` for select types. https://github.com/ricosjp/ruststep/pull/230
 
 ### Internal
-
 - `cargo upgrade --workspace` https://github.com/ricosjp/ruststep/pull/240
 
 ## 0.3.0 - 2022-06-14
 
 ### Added
-
 - Deserialize Record as a struct https://github.com/ricosjp/ruststep/pull/228
 - Add `ruststep::ast::SubSuperRecord` https://github.com/ricosjp/ruststep/pull/225
 - Document and tests for serde mapping in ruststep::ast::de https://github.com/ricosjp/ruststep/pull/220
@@ -48,16 +43,13 @@ In addition to original Keep-a-Changelog, we use following rules:
 - Partial complex entities described in ISO-10303-11 Annex B https://github.com/ricosjp/ruststep/pull/200
 
 ### Changed
-
 - `ruststep::ast::RValue` is renamed to `Name` https://github.com/ricosjp/ruststep/pull/219
 - `ruststep::place_holder` is integrated into `ruststep::tables` https://github.com/ricosjp/ruststep/pull/216
 
 ### Fixed
-
 - `SUBTYPE_CONSTRAINT` cannot parse supertype-constraint like `ONEOF` https://github.com/ricosjp/ruststep/pull/205
 
 ### Internal
-
 - Document for internal mapping https://github.com/ricosjp/ruststep/pull/226
 - Reconstruct documents of ast::de https://github.com/ricosjp/ruststep/pull/229
 - Do not use RecordDeserializer for Name https://github.com/ricosjp/ruststep/pull/224
@@ -69,7 +61,6 @@ In addition to original Keep-a-Changelog, we use following rules:
 ## 0.2.0 - 2022-02-17
 
 ### Added
-
 - Re-expose serde and itertools from ruststep https://github.com/ricosjp/ruststep/pull/199
 - Add the module created from AP203. https://github.com/ricosjp/ruststep/pull/185
 - Implement `AsRef` and `AsMut` for `XXAny`. https://github.com/ricosjp/ruststep/pull/180
@@ -88,9 +79,8 @@ In addition to original Keep-a-Changelog, we use following rules:
 - impl `FromStr` for `Record` and `DataSection` https://github.com/ricosjp/ruststep/pull/140
 
 ### Changed
-
 - Generate Holder struct for TYPE declaration with simple type. https://github.com/ricosjp/ruststep/pull/186
-- Replace the methods `xxx_iter` of `Tables` with `xxx_holder`. https://github.com/ricosjp/ruststep/pull/187
+- Replace the methods `xxx_iter` of `Tables` with `xxx_holder`.  https://github.com/ricosjp/ruststep/pull/187
 - Cut out `IntoOwned` trait from `Holder`. https://github.com/ricosjp/ruststep/pull/183
 - Translates `TYPE` declarations in EXPRESS to Rust tuple struct https://github.com/ricosjp/ruststep/pull/144
 - Visitor struct and all fields in Holder struct become public https://github.com/ricosjp/ruststep/pull/160
@@ -99,7 +89,6 @@ In addition to original Keep-a-Changelog, we use following rules:
 - Use Rust 2021 edition https://github.com/ricosjp/ruststep/pull/128
 
 ### Fixed
-
 - Incorrect `GENERIC` type handling https://github.com/ricosjp/ruststep/pull/198
 - Subtype-Supertype dependency graph generation fixed https://github.com/ricosjp/ruststep/pull/161
 - Supertype field is not included in subtypes type https://github.com/ricosjp/ruststep/pull/166
@@ -107,7 +96,6 @@ In addition to original Keep-a-Changelog, we use following rules:
 - Use raw identifier `r#` for reserved words. https://github.com/ricosjp/ruststep/pull/172
 
 ### Internal
-
 - impl `SeqDeserializer::size_hint` https://github.com/ricosjp/ruststep/pull/197
 - Replace `SeqDeserializer` https://github.com/ricosjp/ruststep/pull/194
 - Use `Record` struct in `Parameter::Typed` https://github.com/ricosjp/ruststep/pull/192

--- a/espr/src/parser/combinator.rs
+++ b/espr/src/parser/combinator.rs
@@ -129,6 +129,13 @@ pub fn not<'a>(f: impl EsprParser<'a, &'a str>) -> impl EsprParser<'a, &'a str> 
     }
 }
 
+pub fn peek<'a>(f: impl EsprParser<'a, &'a str>) -> impl EsprParser<'a, &'a str> {
+    move |input: &'a str| {
+        let (input, _) = nom::combinator::peek(f.clone())(input)?;
+        Ok((input, ("", Vec::new())))
+    }
+}
+
 pub fn char<'a>(c: char) -> impl EsprParser<'a, char> {
     move |input| {
         let (input, c) = nom::character::complete::char(c)(input)?;

--- a/espr/src/parser/literal.rs
+++ b/espr/src/parser/literal.rs
@@ -17,11 +17,15 @@ pub fn literal(input: &str) -> ParseResult<Literal> {
 
 /// 255 logical_literal = `FALSE` | `TRUE` | `UNKNOWN` .
 pub fn logical_literal(input: &str) -> ParseResult<Logical> {
-    alt((
-        value(Logical::True, tag("TRUE")),
-        value(Logical::False, tag("FALSE")),
-        value(Logical::Unknown, tag("UNKNOWN")),
+    tuple((
+        alt((
+            value(Logical::True, tag("TRUE")),
+            value(Logical::False, tag("FALSE")),
+            value(Logical::Unknown, tag("UNKNOWN")),
+        )),
+        peek(not(remarked(nom::character::complete::alpha1))),
     ))
+    .map(|(logical, _non_alpha)| logical)
     .parse(input)
 }
 

--- a/espr/tests/logical_literal.rs
+++ b/espr/tests/logical_literal.rs
@@ -1,0 +1,47 @@
+use espr::{ast::SyntaxTree, codegen::rust::*, ir::IR};
+
+const EXPRESS: &str = r#"
+SCHEMA IFC4X3_DEV_6a23ae8;
+ENTITY IfcGeometricRepresentationContext;
+	TrueNorth : OPTIONAL BOOLEAN;
+ WHERE
+	North2D : NOT(EXISTS(TrueNorth)) OR (HIINDEX(TrueNorth.DirectionRatios) = 2);
+END_ENTITY;
+
+END_SCHEMA;
+"#;
+
+#[test]
+fn logical_literal() {
+    let st = SyntaxTree::parse(EXPRESS).unwrap();
+    let ir = IR::from_syntax_tree(&st).unwrap();
+    let tt = ir.to_token_stream(CratePrefix::External).to_string();
+
+    let tt = rustfmt(tt);
+
+    insta::assert_snapshot!(tt, @r###"
+    pub mod IFC4X3_DEV_6a23ae8 {
+        use ruststep::{as_holder, derive_more::*, primitive::*, Holder, TableInit};
+        use std::collections::HashMap;
+        #[derive(Debug, Clone, PartialEq, Default, TableInit)]
+        pub struct Tables {
+            IfcGeometricRepresentationContext:
+                HashMap<u64, as_holder!(IfcGeometricRepresentationContext)>,
+        }
+        impl Tables {
+            pub fn IfcGeometricRepresentationContext_holders(
+                &self,
+            ) -> &HashMap<u64, as_holder!(IfcGeometricRepresentationContext)> {
+                &self.IfcGeometricRepresentationContext
+            }
+        }
+        #[derive(Debug, Clone, PartialEq, :: derive_new :: new, Holder)]
+        # [holder (table = Tables)]
+        # [holder (field = IfcGeometricRepresentationContext)]
+        #[holder(generate_deserialize)]
+        pub struct IfcGeometricRepresentationContext {
+            pub TrueNorth: Option<bool>,
+        }
+    }
+    "###);
+}


### PR DESCRIPTION
Fixed bug in logical_literal parser. Now it doesn't parse a string starting with "True", "False" or "Unknown" as a logical.

Added test to espr to test the behaviour.