### PR TITLE
Plural class names are converted as is.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 - Recursive `get_owned` for select type without boxed variant. https://github.com/ricosjp/ruststep/pull/234
 
 ### Fixed
+- Plural class names are converted as is.
 - Fixed bug in logical_listeral parser. https://github.com/ricosjp/ruststep/pull/244
 - Deseialize `Option::Some`. https://github.com/ricosjp/ruststep/pull/232
 - Recursive implementation of `ruststep::tables::EntityTable::{get_owned, owned_iter}` for select types. https://github.com/ricosjp/ruststep/pull/230

--- a/ruststep/src/ast/de/parameter.rs
+++ b/ruststep/src/ast/de/parameter.rs
@@ -24,7 +24,7 @@ impl<'de, 'param> de::Deserializer<'de> for &'param Parameter {
             Parameter::Ref(name) => visitor.visit_enum(name),
             Parameter::NotProvided | Parameter::Omitted => visitor.visit_none(),
             Parameter::Enumeration(variant) => {
-                visitor.visit_enum(variant.to_class_case().into_deserializer())
+                visitor.visit_enum(variant.to_pascal_case().into_deserializer())
             }
         }
     }
@@ -39,7 +39,7 @@ impl<'de, 'param> de::Deserializer<'de> for &'param Parameter {
                 "TRUE" => visitor.visit_bool(true),
                 "F" => visitor.visit_bool(false),
                 "FALSE" => visitor.visit_bool(false),
-                _ => visitor.visit_enum(variant.to_class_case().into_deserializer()),
+                _ => visitor.visit_enum(variant.to_pascal_case().into_deserializer()),
             }
         } else {
             self.deserialize_any(visitor)


### PR DESCRIPTION
Fixed a bug that caused enumerated elements whose name is plural to be redefined as singular on their own when deserializing them.